### PR TITLE
Add Satin preset to Sheen effects section

### DIFF
--- a/brdf-viewer.html
+++ b/brdf-viewer.html
@@ -166,6 +166,7 @@
                 <div class="preset-grid">
                     <button class="preset-btn" data-preset="velvet">🌹 Velvet</button>
                     <button class="preset-btn" data-preset="peach">🍑 Peach</button>
+                    <button class="preset-btn" data-preset="satin">🎀 Satin</button>
                     <button class="preset-btn" data-preset="dusty_metal">💨 Dusty Metal</button>
                 </div>
             </div>

--- a/brdf-viewer.js
+++ b/brdf-viewer.js
@@ -172,6 +172,7 @@ const METAL_PRESETS = {
     // Special effects - Sheen examples
     velvet: { color: [0.6, 0.1, 0.2], metallic: 0.0, roughness: 0.8, clearcoat: 0.0, clearcoatRoughness: 0.0, sheen: 1.0 },
     peach: { color: [1.0, 0.8, 0.6], metallic: 0.0, roughness: 0.4, clearcoat: 0.0, clearcoatRoughness: 0.0, sheen: 0.7 },
+    satin: { color: [0.9, 0.8, 0.85], metallic: 0.0, roughness: 0.3, clearcoat: 0.0, clearcoatRoughness: 0.0, sheen: 0.6 },
     dusty_metal: { color: [0.5, 0.5, 0.5], metallic: 1.0, roughness: 0.6, clearcoat: 0.0, clearcoatRoughness: 0.0, sheen: 0.5 },
     // Special effects - Iridescence examples
     soap_bubble: { color: [0.95, 0.95, 0.95], metallic: 0.0, roughness: 0.0, clearcoat: 0.0, clearcoatRoughness: 0.0, iridescence: 1.0, iridescenceIOR: 1.3 },


### PR DESCRIPTION
Added a new Satin (🎀) preset to complete the Sheen effects collection:
- Soft, silky material with subtle rim lighting
- Sheen: 0.6, Roughness: 0.3
- Complements existing Velvet, Peach, and Dusty Metal presets