### PR TITLE
Update Satin color and reset default HSV to neutral

### DIFF
--- a/brdf-viewer.html
+++ b/brdf-viewer.html
@@ -27,20 +27,20 @@
             <div class="color-hsv-group">
                 <div class="color-slider-row">
                     <label>Hue</label>
-                    <input type="range" id="colorH" class="slider-hue" min="0" max="360" step="1" value="200" aria-label="Hue">
+                    <input type="range" id="colorH" class="slider-hue" min="0" max="360" step="1" value="0" aria-label="Hue">
                 </div>
                 <div class="color-slider-row">
                     <label>Saturation</label>
-                    <input type="range" id="colorS" class="slider-saturation" min="0" max="100" step="1" value="95" aria-label="Saturation">
+                    <input type="range" id="colorS" class="slider-saturation" min="0" max="100" step="1" value="0" aria-label="Saturation">
                 </div>
                 <div class="color-slider-row">
                     <label>Value</label>
-                    <input type="range" id="colorV" class="slider-value" min="0" max="100" step="1" value="40" aria-label="Value">
+                    <input type="range" id="colorV" class="slider-value" min="0" max="100" step="1" value="50" aria-label="Value">
                 </div>
             </div>
             <div class="color-display">
                 <div class="color-preview" id="colorPreview"></div>
-                <div class="color-rgb-text" id="colorRGBText">HSV(200°, 95%, 40%)</div>
+                <div class="color-rgb-text" id="colorRGBText">HSV(0°, 0%, 50%)</div>
             </div>
         </div>
 

--- a/brdf-viewer.js
+++ b/brdf-viewer.js
@@ -172,7 +172,7 @@ const METAL_PRESETS = {
     // Special effects - Sheen examples
     velvet: { color: [0.6, 0.1, 0.2], metallic: 0.0, roughness: 0.8, clearcoat: 0.0, clearcoatRoughness: 0.0, sheen: 1.0 },
     peach: { color: [1.0, 0.8, 0.6], metallic: 0.0, roughness: 0.4, clearcoat: 0.0, clearcoatRoughness: 0.0, sheen: 0.7 },
-    satin: { color: [0.9, 0.8, 0.85], metallic: 0.0, roughness: 0.3, clearcoat: 0.0, clearcoatRoughness: 0.0, sheen: 0.6 },
+    satin: { color: [0.02, 0.27, 0.4], metallic: 0.0, roughness: 0.3, clearcoat: 0.0, clearcoatRoughness: 0.0, sheen: 0.6 },
     dusty_metal: { color: [0.5, 0.5, 0.5], metallic: 1.0, roughness: 0.6, clearcoat: 0.0, clearcoatRoughness: 0.0, sheen: 0.5 },
     // Special effects - Iridescence examples
     soap_bubble: { color: [0.95, 0.95, 0.95], metallic: 0.0, roughness: 0.0, clearcoat: 0.0, clearcoatRoughness: 0.0, iridescence: 1.0, iridescenceIOR: 1.3, transmission: 0.9 },


### PR DESCRIPTION
- Changed Satin preset to deep cyan (HSV 200°, 95%, 40%)
- Reset default base color to neutral gray (HSV 0°, 0%, 50%)
- Better showcases sheen effect on darker saturated colors