### PR TITLE
Add environment map selection with multiple HDR options

### DIFF
--- a/brdf-viewer.css
+++ b/brdf-viewer.css
@@ -383,7 +383,8 @@ input[type="range"]::-moz-range-thumb {
     gap: 8px;
 }
 
-.geometry-btn {
+.geometry-btn,
+.environment-btn {
     padding: 10px 8px;
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -395,12 +396,14 @@ input[type="range"]::-moz-range-thumb {
     font-weight: 500;
 }
 
-.geometry-btn.active {
+.geometry-btn.active,
+.environment-btn.active {
     background: rgba(255, 255, 255, 0.2);
     border-color: rgba(255, 255, 255, 0.4);
 }
 
-.geometry-btn:hover {
+.geometry-btn:hover,
+.environment-btn:hover {
     background: rgba(255, 255, 255, 0.15);
     transform: translateY(-2px);
 }

--- a/brdf-viewer.html
+++ b/brdf-viewer.html
@@ -59,6 +59,15 @@
             </div>
         </div>
 
+        <div class="geometry-section">
+            <div class="section-title">🌍 Environment</div>
+            <div class="geometry-grid">
+                <button class="environment-btn active" data-environment="outdoor">🌅 Bright</button>
+                <button class="environment-btn" data-environment="sunset">🌳 Sunset</button>
+                <button class="environment-btn" data-environment="night">🌙 Night</button>
+            </div>
+        </div>
+
         <div class="texture-section">
             <div class="section-title">🗺️ Normal Map</div>
             <input type="file" id="normalMapUpload" accept="image/*" aria-label="Upload normal map">

--- a/brdf-viewer.js
+++ b/brdf-viewer.js
@@ -277,23 +277,49 @@ function initViewer() {
     controls.enableDamping = true;
     controls.dampingFactor = 0.05;
 
-    // Load HDR environment map
+    // HDR Environment maps
+    const hdriMaps = {
+        outdoor: {
+            name: '🌅 Bright Outdoor',
+            url: 'https://threejs.org/examples/textures/equirectangular/royal_esplanade_1k.hdr'
+        },
+        sunset: {
+            name: '🌳 Sunset Nature',
+            url: 'https://threejs.org/examples/textures/equirectangular/venice_sunset_1k.hdr'
+        },
+        night: {
+            name: '🌙 Dark Night',
+            url: 'https://threejs.org/examples/textures/equirectangular/dikhololo_night_1k.hdr'
+        }
+    };
+
     let envMap = null;
     let iblEnabled = true;
     const rgbeLoader = new RGBELoader();
 
-    rgbeLoader.load(
-        'https://threejs.org/examples/textures/equirectangular/royal_esplanade_1k.hdr',
-        function (texture) {
-            texture.mapping = THREE.EquirectangularReflectionMapping;
-            envMap = texture;
-            scene.environment = texture;
-        },
-        undefined,
-        function (error) {
-            console.error('Error loading HDR:', error);
-        }
-    );
+    // Function to load environment map
+    function loadEnvironment(key) {
+        const hdri = hdriMaps[key];
+        if (!hdri) return;
+
+        rgbeLoader.load(
+            hdri.url,
+            function (texture) {
+                texture.mapping = THREE.EquirectangularReflectionMapping;
+                envMap = texture;
+                if (iblEnabled) {
+                    scene.environment = texture;
+                }
+            },
+            undefined,
+            function (error) {
+                console.error('Error loading HDR:', error);
+            }
+        );
+    }
+
+    // Load default environment
+    loadEnvironment('outdoor');
 
     // Lighting
     const light1 = new THREE.DirectionalLight(0xffffff, 1.0);
@@ -485,6 +511,18 @@ function initViewer() {
 
             // Update active button
             document.querySelectorAll('.geometry-btn').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+        });
+    });
+
+    // Environment switching
+    document.querySelectorAll('.environment-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const envType = btn.dataset.environment;
+            loadEnvironment(envType);
+
+            // Update active button
+            document.querySelectorAll('.environment-btn').forEach(b => b.classList.remove('active'));
             btn.classList.add('active');
         });
     });


### PR DESCRIPTION
Added three HDR environment map options:
- 🌅 Bright Outdoor: Clear daylight (royal_esplanade)
- 🌳 Sunset Nature: Warm sunset atmosphere (venice_sunset)
- 🌙 Dark Night: Dark evening ambiance (dikhololo_night)

Features:
- Environment selection buttons in UI
- Real-time HDR map switching
- Maintains IBL toggle functionality
- Consistent button styling with geometry selection