### PR TITLE
Update typography with influential typefaces and extreme contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>김소연 - Portfolio</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Pretendard:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700;800;900&family=IBM+Plex+Sans:wght@300;400;600&family=JetBrains+Mono:wght@400;500;700&family=Pretendard:wght@300;400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/style.css
+++ b/style.css
@@ -47,10 +47,12 @@ html {
 }
 
 body {
-    font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-family: 'IBM Plex Sans', 'Pretendard', sans-serif;
     background-color: var(--bg-primary);
     color: var(--text-primary);
     line-height: 1.6;
+    font-weight: 300;
+    font-size: 18px;
     transition: background-color 0.3s ease, color 0.3s ease;
 }
 
@@ -87,8 +89,9 @@ nav {
 }
 
 .logo {
-    font-size: 1.5rem;
-    font-weight: 700;
+    font-family: 'Playfair Display', 'Pretendard', serif;
+    font-size: 1.75rem;
+    font-weight: 900;
     background: var(--gradient);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -108,9 +111,11 @@ nav {
 }
 
 .nav-menu a {
+    font-family: 'IBM Plex Sans', 'Pretendard', sans-serif;
     color: var(--text-primary);
     text-decoration: none;
-    font-weight: 500;
+    font-weight: 600;
+    font-size: 0.95rem;
     transition: var(--transition);
     position: relative;
 }
@@ -289,10 +294,12 @@ nav {
 }
 
 .hero-title {
-    font-size: 3.5rem;
-    font-weight: 700;
-    line-height: 1.2;
+    font-family: 'Playfair Display', 'Pretendard', serif;
+    font-size: 5rem;
+    font-weight: 900;
+    line-height: 1.1;
     margin-bottom: var(--spacing-sm);
+    letter-spacing: -0.02em;
 }
 
 .gradient-text {
@@ -314,9 +321,12 @@ nav {
 }
 
 .hero-description {
-    font-size: 1.25rem;
+    font-family: 'JetBrains Mono', 'Pretendard', monospace;
+    font-size: 1.1rem;
+    font-weight: 400;
     color: var(--text-secondary);
     margin-bottom: var(--spacing-md);
+    letter-spacing: 0.02em;
 }
 
 .hero-image {
@@ -344,13 +354,16 @@ nav {
 
 /* ==================== Buttons ==================== */
 .btn {
+    font-family: 'IBM Plex Sans', 'Pretendard', sans-serif;
     display: inline-block;
     padding: 0.875rem 2rem;
     border-radius: 50px;
     text-decoration: none;
     font-weight: 600;
+    font-size: 1rem;
     transition: var(--transition);
     border: 2px solid transparent;
+    letter-spacing: 0.01em;
 }
 
 .btn-primary {
@@ -379,26 +392,32 @@ nav {
 }
 
 .section-title {
-    font-size: 2.5rem;
-    font-weight: 700;
+    font-family: 'Playfair Display', 'Pretendard', serif;
+    font-size: 4rem;
+    font-weight: 800;
     margin-bottom: var(--spacing-sm);
     text-align: center;
+    letter-spacing: -0.01em;
+    line-height: 1.15;
 }
 
 .section-description {
+    font-family: 'IBM Plex Sans', 'Pretendard', sans-serif;
     text-align: center;
     color: var(--text-secondary);
     font-size: 1.125rem;
     margin-bottom: var(--spacing-lg);
-    font-weight: 400;
+    font-weight: 300;
 }
 
 .section-subtitle {
-    font-size: 1.75rem;
-    font-weight: 600;
+    font-family: 'Playfair Display', 'Pretendard', serif;
+    font-size: 2.5rem;
+    font-weight: 700;
     margin-top: var(--spacing-lg);
     margin-bottom: var(--spacing-md);
     color: var(--text-primary);
+    letter-spacing: -0.01em;
 }
 
 /* ==================== Cards ==================== */
@@ -417,10 +436,12 @@ nav {
 }
 
 .card-title {
+    font-family: 'IBM Plex Sans', 'Pretendard', sans-serif;
     display: flex;
     align-items: center;
     gap: var(--spacing-xs);
     font-size: 1.5rem;
+    font-weight: 600;
     margin-bottom: var(--spacing-sm);
     color: var(--text-primary);
 }
@@ -559,7 +580,9 @@ nav {
 }
 
 .resume-item h4 {
+    font-family: 'IBM Plex Sans', 'Pretendard', sans-serif;
     font-size: 1.125rem;
+    font-weight: 600;
     margin-bottom: 0.5rem;
     color: var(--text-primary);
 }
@@ -609,10 +632,11 @@ nav {
 }
 
 .experience-header h4 {
+    font-family: 'IBM Plex Sans', 'Pretendard', sans-serif;
     font-size: 1.25rem;
     color: var(--text-primary);
     margin: 0;
-    font-weight: 700;
+    font-weight: 600;
 }
 
 .experience-period {
@@ -622,8 +646,9 @@ nav {
 }
 
 .experience-role {
+    font-family: 'IBM Plex Sans', 'Pretendard', sans-serif;
     color: var(--text-primary);
-    font-weight: 700;
+    font-weight: 600;
     font-size: 1.1rem;
     margin-bottom: 0.25rem;
     margin-top: 0.5rem;
@@ -670,7 +695,9 @@ nav {
 }
 
 .award-item h4 {
+    font-family: 'IBM Plex Sans', 'Pretendard', sans-serif;
     font-size: 1.125rem;
+    font-weight: 600;
     color: var(--text-primary);
     margin-bottom: 0.5rem;
 }
@@ -702,9 +729,11 @@ nav {
 }
 
 .skill-name {
-    font-weight: 600;
+    font-family: 'JetBrains Mono', 'Pretendard', monospace;
+    font-weight: 500;
     color: var(--text-primary);
-    font-size: 1rem;
+    font-size: 0.95rem;
+    letter-spacing: 0.01em;
 }
 
 .skill-bar {
@@ -883,7 +912,9 @@ nav {
 }
 
 .portfolio-content h3 {
+    font-family: 'IBM Plex Sans', 'Pretendard', sans-serif;
     font-size: 1.25rem;
+    font-weight: 600;
     margin-bottom: var(--spacing-sm);
     position: relative;
     padding-left: 0.75rem;
@@ -985,7 +1016,9 @@ nav {
 }
 
 .contact-card h3 {
+    font-family: 'IBM Plex Sans', 'Pretendard', sans-serif;
     font-size: 1.25rem;
+    font-weight: 600;
     margin-bottom: var(--spacing-xs);
 }
 
@@ -1049,7 +1082,7 @@ footer p {
     }
 
     .hero-title {
-        font-size: 2.5rem;
+        font-size: 3rem;
     }
 
     .hero-buttons {
@@ -1061,7 +1094,7 @@ footer p {
     }
 
     .section-title {
-        font-size: 2rem;
+        font-size: 2.5rem;
     }
 
     .resume-grid,
@@ -1105,11 +1138,15 @@ footer p {
 
 @media (max-width: 480px) {
     .hero-title {
-        font-size: 2rem;
+        font-size: 2.25rem;
     }
 
     .hero-description {
-        font-size: 1rem;
+        font-size: 0.95rem;
+    }
+
+    .section-title {
+        font-size: 2rem;
     }
 
     .hero-buttons {


### PR DESCRIPTION
Implemented typography guidelines with semantic distinction:
- Display: Playfair Display (800-900 weight) for hero and section titles
- Body: IBM Plex Sans (300-600 weight) for UI and content
- Technical: JetBrains Mono for skills and descriptive elements
- Maintained Pretendard as fallback for Korean text support

Applied extreme contrast principles:
- Hero title: 5rem (80px) with 900 weight
- Section titles: 4rem (64px) with 800 weight
- Body text: 18px with 300 weight
- Achieves 4.4x+ scaling ratio between headings and body

Enhanced visual hierarchy with variable weights (300, 600, 700-900) and tight letter-spacing (-0.02em to 0.02em) for refined appearance.