### PR TITLE
Implement three-tier skill level system with visual dividers

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,37 +125,37 @@
                         <div class="skill-level-item">
                             <span class="skill-name">3ds Max</span>
                             <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="90"></div>
+                                <div class="skill-bar-fill" data-width="100"></div>
                             </div>
                         </div>
                         <div class="skill-level-item">
                             <span class="skill-name">Photoshop</span>
                             <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="90"></div>
+                                <div class="skill-bar-fill" data-width="100"></div>
                             </div>
                         </div>
                         <div class="skill-level-item">
                             <span class="skill-name">ZBrush</span>
                             <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="80"></div>
+                                <div class="skill-bar-fill" data-width="100"></div>
                             </div>
                         </div>
                         <div class="skill-level-item">
                             <span class="skill-name">Substance 3D Designer</span>
                             <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="70"></div>
+                                <div class="skill-bar-fill" data-width="67"></div>
                             </div>
                         </div>
                         <div class="skill-level-item">
                             <span class="skill-name">Substance 3D Painter</span>
                             <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="60"></div>
+                                <div class="skill-bar-fill" data-width="67"></div>
                             </div>
                         </div>
                         <div class="skill-level-item">
                             <span class="skill-name">Blender</span>
                             <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="60"></div>
+                                <div class="skill-bar-fill" data-width="67"></div>
                             </div>
                         </div>
 
@@ -166,13 +166,13 @@
                         <div class="skill-level-item">
                             <span class="skill-name">Unity</span>
                             <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="90"></div>
+                                <div class="skill-bar-fill" data-width="100"></div>
                             </div>
                         </div>
                         <div class="skill-level-item">
                             <span class="skill-name">Unreal Engine</span>
                             <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="70"></div>
+                                <div class="skill-bar-fill" data-width="67"></div>
                             </div>
                         </div>
 
@@ -183,19 +183,19 @@
                         <div class="skill-level-item">
                             <span class="skill-name">SourceTree</span>
                             <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="90"></div>
+                                <div class="skill-bar-fill" data-width="100"></div>
                             </div>
                         </div>
                         <div class="skill-level-item">
                             <span class="skill-name">Confluence Wiki</span>
                             <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="90"></div>
+                                <div class="skill-bar-fill" data-width="100"></div>
                             </div>
                         </div>
                         <div class="skill-level-item">
                             <span class="skill-name">Git</span>
                             <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="80"></div>
+                                <div class="skill-bar-fill" data-width="100"></div>
                             </div>
                         </div>
                     </div>

--- a/style.css
+++ b/style.css
@@ -747,9 +747,35 @@ nav {
     height: 10px;
     background: var(--bg-secondary);
     border-radius: 50px;
-    overflow: hidden;
+    overflow: visible;
     position: relative;
     border: 1px solid var(--border-color);
+}
+
+.skill-bar::before,
+.skill-bar::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 2px;
+    height: 14px;
+    background: white;
+    z-index: 10;
+    border-radius: 1px;
+}
+
+[data-theme="dark"] .skill-bar::before,
+[data-theme="dark"] .skill-bar::after {
+    background: rgba(255, 255, 255, 0.8);
+}
+
+.skill-bar::before {
+    left: 33.33%;
+}
+
+.skill-bar::after {
+    left: 66.66%;
 }
 
 .skill-bar-fill {


### PR DESCRIPTION
Replace percentage-based skill bars with clear three-tier system (상/중/하):
- Add white dividing lines at 33% and 67% positions for visual clarity
- Update all skills to snap to three tiers: 100% (상), 67% (중), or 33% (하)
- High tier (100%): 3ds Max, Photoshop, ZBrush, Unity, SourceTree, Confluence Wiki, Git
- Medium tier (67%): Substance 3D Designer/Painter, Blender, Unreal Engine

This approach provides clearer skill categorization without implying exact percentage mastery.