### PR TITLE
Separate grouped awards into individual items

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,27 +299,25 @@
             <!-- Awards Section -->
             <h3 class="section-subtitle">Awards & Activities</h3>
             <div class="awards-grid">
-                <div class="award-item award-group">
-                    <h4>BIC 2018 & STEP UP! PROJECT</h4>
-                    <div class="award-subitem">
-                        <p class="award-project">BIC 2018 EXCELLENCE IN CASUAL - Colorzzle</p>
-                        <span class="award-date">2018.09</span>
-                    </div>
-                    <div class="award-subitem">
-                        <p class="award-project">STEP UP! PROJECT GRAND PRIZE - Color Puzzle (성남산업진흥재단)</p>
-                        <span class="award-date">2017.09</span>
-                    </div>
+                <div class="award-item">
+                    <h4>BIC 2018 EXCELLENCE IN CASUAL</h4>
+                    <p class="award-project">Colorzzle</p>
+                    <span class="award-date">2018.09</span>
                 </div>
-                <div class="award-item award-group">
+                <div class="award-item">
+                    <h4>STEP UP! PROJECT GRAND PRIZE</h4>
+                    <p class="award-project">Color Puzzle (성남산업진흥재단)</p>
+                    <span class="award-date">2017.09</span>
+                </div>
+                <div class="award-item">
                     <h4>한국게임학회 추계 학술대회 논문 수록</h4>
-                    <div class="award-subitem">
-                        <p class="award-project">3DGS 기반 게임 제작 교육의 실행 가능성 탐색: 게임 특성화 고등학교 사례 연구</p>
-                        <span class="award-date">2025.11</span>
-                    </div>
-                    <div class="award-subitem">
-                        <p class="award-project">Photogrammetry와 NeRF의 비교분석을 통한 실사 오브젝트 제작 방식의 미래 방향성 제안</p>
-                        <span class="award-date">2024.11</span>
-                    </div>
+                    <p class="award-project">3DGS기반 게임 제작 교육의 실행 가능성 탐색: 게임 특성화 고등학교 사례 연구</p>
+                    <span class="award-date">2025.11</span>
+                </div>
+                <div class="award-item">
+                    <h4>한국게임학회 추계 학술대회 논문 수록</h4>
+                    <p class="award-project">Photogrammetry와 NeRF의 비교분석을 통한 실사 오브젝트 제작 방식의 미래 방향성 제안</p>
+                    <span class="award-date">2024.11</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Split BIC 2018 and STEP UP! PROJECT into separate award items
- Split Korean Game Society papers into individual items
- Remove award-group structure for clearer separation
- Each award is now its own distinct entry
- Fix spacing: 3DGS 기반 → 3DGS기반