### PR TITLE
Add year prefix to conference paper titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,12 +315,12 @@
             <h3 class="section-subtitle">Research Papers</h3>
             <div class="awards-grid">
                 <div class="award-item">
-                    <h4>한국게임학회 추계 학술대회 논문 수록</h4>
+                    <h4>2025 한국게임학회 추계 학술대회 논문 수록</h4>
                     <p class="award-project">3DGS기반 게임 제작 교육의 실행 가능성 탐색: 게임 특성화 고등학교 사례 연구</p>
                     <span class="award-date">2025.11</span>
                 </div>
                 <div class="award-item">
-                    <h4>한국게임학회 추계 학술대회 논문 수록</h4>
+                    <h4>2024 한국게임학회 추계 학술대회 논문 수록</h4>
                     <p class="award-project">Photogrammetry와 NeRF의 비교분석을 통한 실사 오브젝트 제작 방식의 미래 방향성 제안</p>
                     <span class="award-date">2024.11</span>
                 </div>


### PR DESCRIPTION
- Distinguish 2025 and 2024 papers by adding year prefix
- Prevents duplicate appearance of identical conference names