### PR TITLE
Fix experience logos positioning on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -604,6 +604,8 @@ nav {
     border-radius: 15px;
     padding: var(--spacing-md);
     transition: var(--transition);
+    position: relative;
+    overflow: hidden;
 }
 
 .experience-item:hover {


### PR DESCRIPTION
Add position: relative and overflow: hidden to .experience-item to properly contain absolutely positioned logos within their parent containers. This prevents logos from appearing in wrong sections on mobile view.