### PR TITLE
Fix strict mode error: rename 'eval' to 'evaluation'

### DIFF
--- a/thesis-simulator.js
+++ b/thesis-simulator.js
@@ -623,12 +623,12 @@ function updateEvaluationDisplay() {
         return;
     }
 
-    evalList.innerHTML = state.evaluations.slice(-10).reverse().map((eval, index) => `
+    evalList.innerHTML = state.evaluations.slice(-10).reverse().map((evaluation, index) => `
         <div class="eval-item">
-            <strong>#${state.evaluations.length - index}</strong> - ${eval.material.toUpperCase()} |
-            Blend: ${eval.styleBlend}% |
-            Rating: ${eval.rating}/${eval.scaleType} |
-            ${new Date(eval.timestamp).toLocaleTimeString('ko-KR')}
+            <strong>#${state.evaluations.length - index}</strong> - ${evaluation.material.toUpperCase()} |
+            Blend: ${evaluation.styleBlend}% |
+            Rating: ${evaluation.rating}/${evaluation.scaleType} |
+            ${new Date(evaluation.timestamp).toLocaleTimeString('ko-KR')}
         </div>
     `).join('');
 }
@@ -654,16 +654,16 @@ function exportEvaluationsToCSV() {
     ];
 
     // Create CSV rows
-    const rows = state.evaluations.map(eval => [
-        eval.timestamp,
-        eval.material,
-        eval.styleBlend,
-        eval.scaleType,
-        eval.rating,
-        eval.viewMode,
-        eval.displacementScale,
-        eval.geometryDetail,
-        eval.environment
+    const rows = state.evaluations.map(evaluation => [
+        evaluation.timestamp,
+        evaluation.material,
+        evaluation.styleBlend,
+        evaluation.scaleType,
+        evaluation.rating,
+        evaluation.viewMode,
+        evaluation.displacementScale,
+        evaluation.geometryDetail,
+        evaluation.environment
     ]);
 
     // Combine header and rows


### PR DESCRIPTION
strict mode에서 eval 변수명 사용 불가 에러 수정:
- map 함수 파라미터 eval → evaluation 변경
- JavaScript 예약어 충돌 해결
- SyntaxError 수정으로 공 렌더링 복구