### PR TITLE
Add 7-segment bar with snapping behavior and vertical handle

### DIFF
--- a/thesis-simulator.css
+++ b/thesis-simulator.css
@@ -137,35 +137,55 @@ body {
 
 .style-slider {
     width: 100%;
-    height: 8px;
-    border-radius: 10px;
+    height: 12px;
+    border-radius: 4px;
     outline: none;
     -webkit-appearance: none;
-    background: linear-gradient(to right, #4ade80 0%, #f472b6 100%);
+    background:
+        /* Segment dividers */
+        repeating-linear-gradient(
+            to right,
+            transparent 0px,
+            transparent calc(100% / 7 - 2px),
+            rgba(20, 20, 40, 0.8) calc(100% / 7 - 2px),
+            rgba(20, 20, 40, 0.8) calc(100% / 7),
+            transparent calc(100% / 7)
+        ),
+        /* Color gradient */
+        linear-gradient(to right, #4ade80 0%, #f472b6 100%);
     cursor: pointer;
     margin-bottom: 0.8rem;
+    position: relative;
 }
 
 .style-slider::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
+    width: 12px;
+    height: 32px;
+    border-radius: 3px;
     background: white;
-    cursor: pointer;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-    border: 3px solid #667eea;
+    cursor: grab;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.5);
+    border: 2px solid #667eea;
+}
+
+.style-slider::-webkit-slider-thumb:active {
+    cursor: grabbing;
 }
 
 .style-slider::-moz-range-thumb {
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
+    width: 12px;
+    height: 32px;
+    border-radius: 3px;
     background: white;
-    cursor: pointer;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-    border: 3px solid #667eea;
+    cursor: grab;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.5);
+    border: 2px solid #667eea;
+}
+
+.style-slider::-moz-range-thumb:active {
+    cursor: grabbing;
 }
 
 .spectrum-value {

--- a/thesis-simulator.js
+++ b/thesis-simulator.js
@@ -389,17 +389,55 @@ function rebuildAllGeometries() {
     console.log(`Rebuilt all geometries with detail: ${detail}`);
 }
 
+// ===== Snap to Segment =====
+function snapToSegment(value) {
+    // 7 segments: 0, 16.67, 33.33, 50, 66.67, 83.33, 100
+    const segments = [0, 16.67, 33.33, 50, 66.67, 83.33, 100];
+
+    // Find closest segment
+    let closest = segments[0];
+    let minDiff = Math.abs(value - closest);
+
+    for (let i = 1; i < segments.length; i++) {
+        const diff = Math.abs(value - segments[i]);
+        if (diff < minDiff) {
+            minDiff = diff;
+            closest = segments[i];
+        }
+    }
+
+    return closest;
+}
+
 // ===== Setup Event Listeners =====
 function setupEventListeners() {
     // Style slider
     const styleSlider = document.getElementById('globalStyleSlider');
     const styleValue = document.getElementById('styleValue');
 
+    // Input event for smooth preview (optional - can be removed for immediate snapping)
     styleSlider.addEventListener('input', (e) => {
-        state.styleBlend = parseFloat(e.target.value);
-        styleValue.textContent = Math.round(state.styleBlend);
+        const rawValue = parseFloat(e.target.value);
+        state.styleBlend = rawValue;
+        styleValue.textContent = Math.round(rawValue);
 
         // Update all materials
+        Object.keys(materials).forEach(matName => {
+            updateMaterialTextures(matName);
+        });
+    });
+
+    // Change event for snapping
+    styleSlider.addEventListener('change', (e) => {
+        const rawValue = parseFloat(e.target.value);
+        const snappedValue = snapToSegment(rawValue);
+
+        // Update slider to snapped value
+        e.target.value = snappedValue;
+        state.styleBlend = snappedValue;
+        styleValue.textContent = Math.round(snappedValue);
+
+        // Update all materials with snapped value
         Object.keys(materials).forEach(matName => {
             updateMaterialTextures(matName);
         });


### PR DESCRIPTION
- Divide style slider into 7 clear segments with visual boundaries
- Change circular thumb to vertical rectangular handle (12x32px)
- Implement snapping behavior to lock slider to segment positions
- Segments at: 0%, 16.67%, 33.33%, 50%, 66.67%, 83.33%, 100%
- Enhanced visual feedback with grab cursor states