### PR TITLE
Replace global slider with individual per-material sliders

### DIFF
--- a/thesis-simulator.css
+++ b/thesis-simulator.css
@@ -831,19 +831,42 @@ body {
     padding: 0.8rem 1rem;
     border-top: 1px solid rgba(100, 255, 218, 0.2);
     display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.viewport-header {
+    display: flex;
     align-items: center;
-    gap: 0.8rem;
+    gap: 0.6rem;
 }
 
 .material-icon {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
 }
 
 .material-name {
-    font-size: 0.95rem;
+    font-size: 0.9rem;
     font-weight: 600;
     color: #e0e0e0;
     flex: 1;
+}
+
+.viewport-slider-container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.viewport-slider-container .spectrum-labels {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.7rem;
+}
+
+.viewport-slider-container .style-slider {
+    height: 10px;
+    margin-bottom: 0;
 }
 
 /* ===== Style Indicator ===== */

--- a/thesis-simulator.html
+++ b/thesis-simulator.html
@@ -22,20 +22,6 @@
     <div class="main-container">
         <!-- Left Sidebar - Controls -->
         <aside class="control-sidebar">
-            <div class="control-section">
-                <h2>🎨 Style Spectrum Control</h2>
-                <div class="spectrum-control">
-                    <div class="spectrum-labels">
-                        <span class="label-realistic">실사 Realistic</span>
-                        <span class="label-stylized">스타일라이즈 Stylized</span>
-                    </div>
-                    <input type="range" id="globalStyleSlider" min="0" max="100" value="0" class="style-slider">
-                    <div class="spectrum-value">
-                        <span id="styleValue">0</span>%
-                    </div>
-                </div>
-            </div>
-
             <!-- View Mode -->
             <div class="control-section">
                 <h2>📐 View Mode</h2>
@@ -449,12 +435,16 @@
                 <div class="viewport-item" data-material="wood">
                     <div class="viewport-canvas" id="canvas-wood"></div>
                     <div class="viewport-label">
-                        <span class="material-icon">🪵</span>
-                        <span class="material-name">Wood (나무)</span>
-                        <div class="style-indicator">
-                            <span class="realistic-badge">Realistic</span>
-                            <div class="blend-bar"><div class="blend-fill" style="width: 0%"></div></div>
-                            <span class="stylized-badge">Stylized</span>
+                        <div class="viewport-header">
+                            <span class="material-icon">🪵</span>
+                            <span class="material-name">Wood (나무)</span>
+                        </div>
+                        <div class="viewport-slider-container">
+                            <div class="spectrum-labels">
+                                <span class="label-realistic">Realistic</span>
+                                <span class="label-stylized">Stylized</span>
+                            </div>
+                            <input type="range" class="style-slider" data-material="wood" min="0" max="100" value="0">
                         </div>
                     </div>
                 </div>
@@ -462,12 +452,16 @@
                 <div class="viewport-item" data-material="stone">
                     <div class="viewport-canvas" id="canvas-stone"></div>
                     <div class="viewport-label">
-                        <span class="material-icon">🪨</span>
-                        <span class="material-name">Stone (돌)</span>
-                        <div class="style-indicator">
-                            <span class="realistic-badge">Realistic</span>
-                            <div class="blend-bar"><div class="blend-fill" style="width: 0%"></div></div>
-                            <span class="stylized-badge">Stylized</span>
+                        <div class="viewport-header">
+                            <span class="material-icon">🪨</span>
+                            <span class="material-name">Stone (돌)</span>
+                        </div>
+                        <div class="viewport-slider-container">
+                            <div class="spectrum-labels">
+                                <span class="label-realistic">Realistic</span>
+                                <span class="label-stylized">Stylized</span>
+                            </div>
+                            <input type="range" class="style-slider" data-material="stone" min="0" max="100" value="0">
                         </div>
                     </div>
                 </div>
@@ -475,12 +469,16 @@
                 <div class="viewport-item" data-material="metal">
                     <div class="viewport-canvas" id="canvas-metal"></div>
                     <div class="viewport-label">
-                        <span class="material-icon">⚙️</span>
-                        <span class="material-name">Metal (금속)</span>
-                        <div class="style-indicator">
-                            <span class="realistic-badge">Realistic</span>
-                            <div class="blend-bar"><div class="blend-fill" style="width: 0%"></div></div>
-                            <span class="stylized-badge">Stylized</span>
+                        <div class="viewport-header">
+                            <span class="material-icon">⚙️</span>
+                            <span class="material-name">Metal (금속)</span>
+                        </div>
+                        <div class="viewport-slider-container">
+                            <div class="spectrum-labels">
+                                <span class="label-realistic">Realistic</span>
+                                <span class="label-stylized">Stylized</span>
+                            </div>
+                            <input type="range" class="style-slider" data-material="metal" min="0" max="100" value="0">
                         </div>
                     </div>
                 </div>
@@ -488,12 +486,16 @@
                 <div class="viewport-item" data-material="cloth">
                     <div class="viewport-canvas" id="canvas-cloth"></div>
                     <div class="viewport-label">
-                        <span class="material-icon">🧵</span>
-                        <span class="material-name">Cloth (천)</span>
-                        <div class="style-indicator">
-                            <span class="realistic-badge">Realistic</span>
-                            <div class="blend-bar"><div class="blend-fill" style="width: 0%"></div></div>
-                            <span class="stylized-badge">Stylized</span>
+                        <div class="viewport-header">
+                            <span class="material-icon">🧵</span>
+                            <span class="material-name">Cloth (천)</span>
+                        </div>
+                        <div class="viewport-slider-container">
+                            <div class="spectrum-labels">
+                                <span class="label-realistic">Realistic</span>
+                                <span class="label-stylized">Stylized</span>
+                            </div>
+                            <input type="range" class="style-slider" data-material="cloth" min="0" max="100" value="0">
                         </div>
                     </div>
                 </div>
@@ -504,12 +506,16 @@
                 <div class="viewport-item-large">
                     <div class="viewport-canvas" id="canvas-single"></div>
                     <div class="viewport-label">
-                        <span class="material-icon">🪵</span>
-                        <span class="material-name">Wood (나무)</span>
-                        <div class="style-indicator">
-                            <span class="realistic-badge">Realistic</span>
-                            <div class="blend-bar"><div class="blend-fill" style="width: 0%"></div></div>
-                            <span class="stylized-badge">Stylized</span>
+                        <div class="viewport-header">
+                            <span class="material-icon" id="single-icon">🪵</span>
+                            <span class="material-name" id="single-name">Wood (나무)</span>
+                        </div>
+                        <div class="viewport-slider-container">
+                            <div class="spectrum-labels">
+                                <span class="label-realistic">Realistic</span>
+                                <span class="label-stylized">Stylized</span>
+                            </div>
+                            <input type="range" class="style-slider" id="single-slider" data-material="wood" min="0" max="100" value="0">
                         </div>
                     </div>
                 </div>
@@ -520,15 +526,19 @@
                 <div class="viewport-item-large">
                     <div class="viewport-canvas" id="canvas-compare-left"></div>
                     <div class="viewport-label">
-                        <span class="material-icon">🪵</span>
-                        <span class="material-name">Wood - Realistic</span>
+                        <div class="viewport-header">
+                            <span class="material-icon" id="compare-left-icon">🪵</span>
+                            <span class="material-name">Wood - Realistic</span>
+                        </div>
                     </div>
                 </div>
                 <div class="viewport-item-large">
                     <div class="viewport-canvas" id="canvas-compare-right"></div>
                     <div class="viewport-label">
-                        <span class="material-icon">🪵</span>
-                        <span class="material-name">Wood - Stylized</span>
+                        <div class="viewport-header">
+                            <span class="material-icon" id="compare-right-icon">🪵</span>
+                            <span class="material-name">Wood - Stylized</span>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
- Remove global style slider and percentage display from sidebar
- Add individual 7-segment sliders to each viewport label
- Each material now tracks its own styleBlend value independently
- Update CSS for compact viewport slider layout
- Update event listeners to handle per-material slider changes
- Single view slider syncs with selected material's blend value