### PR TITLE
Reorganize Skills section with new categories and grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
                 </div>
 
                 <!-- Skills Card -->
-                <div class="card" id="skillCard">
+                <div class="card card-wide" id="skillCard">
                     <h3 class="card-title">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <polygon points="12 2 2 7 12 12 22 7 12 2"></polygon>
@@ -120,83 +120,89 @@
                         </svg>
                         Skills
                     </h3>
-                    <div class="skills-progress-list">
-                        <!-- Graphics Tools -->
-                        <div class="skill-category-title">Graphics Tools</div>
-                        <div class="skill-level-item">
-                            <span class="skill-name">3ds Max</span>
-                            <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="100"></div>
+                    <div class="skills-grid">
+                        <!-- Environment -->
+                        <div class="skills-column">
+                            <div class="skill-category-title">Environment</div>
+                            <div class="skill-level-item">
+                                <span class="skill-name">Modular Level Design</span>
+                                <div class="skill-bar">
+                                    <div class="skill-bar-fill" data-width="100"></div>
+                                </div>
                             </div>
-                        </div>
-                        <div class="skill-level-item">
-                            <span class="skill-name">Photoshop</span>
-                            <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="100"></div>
+                            <div class="skill-level-item">
+                                <span class="skill-name">Terrain & Landscape</span>
+                                <div class="skill-bar">
+                                    <div class="skill-bar-fill" data-width="100"></div>
+                                </div>
                             </div>
-                        </div>
-                        <div class="skill-level-item">
-                            <span class="skill-name">ZBrush</span>
-                            <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="100"></div>
-                            </div>
-                        </div>
-                        <div class="skill-level-item">
-                            <span class="skill-name">Substance 3D Designer</span>
-                            <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="67"></div>
-                            </div>
-                        </div>
-                        <div class="skill-level-item">
-                            <span class="skill-name">Substance 3D Painter</span>
-                            <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="67"></div>
-                            </div>
-                        </div>
-                        <div class="skill-level-item">
-                            <span class="skill-name">Blender</span>
-                            <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="67"></div>
+                            <div class="skill-level-item">
+                                <span class="skill-name">Prop Modeling</span>
+                                <div class="skill-bar">
+                                    <div class="skill-bar-fill" data-width="100"></div>
+                                </div>
                             </div>
                         </div>
 
-                        <div class="skill-divider"></div>
+                        <!-- FX -->
+                        <div class="skills-column">
+                            <div class="skill-category-title">FX</div>
+                            <div class="skill-level-item">
+                                <span class="skill-name">Particle System</span>
+                                <div class="skill-bar">
+                                    <div class="skill-bar-fill" data-width="100"></div>
+                                </div>
+                            </div>
+                            <div class="skill-level-item">
+                                <span class="skill-name">Shader VFX</span>
+                                <div class="skill-bar">
+                                    <div class="skill-bar-fill" data-width="67"></div>
+                                </div>
+                            </div>
+                        </div>
 
-                        <!-- Game Engines -->
-                        <div class="skill-category-title">Game Engines</div>
-                        <div class="skill-level-item">
-                            <span class="skill-name">Unity</span>
-                            <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="100"></div>
+                        <!-- Character -->
+                        <div class="skills-column">
+                            <div class="skill-category-title">Character</div>
+                            <div class="skill-level-item">
+                                <span class="skill-name">Character Modeling</span>
+                                <div class="skill-bar">
+                                    <div class="skill-bar-fill" data-width="100"></div>
+                                </div>
                             </div>
-                        </div>
-                        <div class="skill-level-item">
-                            <span class="skill-name">Unreal Engine</span>
-                            <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="67"></div>
+                            <div class="skill-level-item">
+                                <span class="skill-name">Rigging</span>
+                                <div class="skill-bar">
+                                    <div class="skill-bar-fill" data-width="67"></div>
+                                </div>
                             </div>
                         </div>
 
-                        <div class="skill-divider"></div>
+                        <!-- Animation -->
+                        <div class="skills-column">
+                            <div class="skill-category-title">Animation</div>
+                            <div class="skill-level-item">
+                                <span class="skill-name">Keyframe Animation</span>
+                                <div class="skill-bar">
+                                    <div class="skill-bar-fill" data-width="100"></div>
+                                </div>
+                            </div>
+                            <div class="skill-level-item">
+                                <span class="skill-name">Motion Graphics</span>
+                                <div class="skill-bar">
+                                    <div class="skill-bar-fill" data-width="67"></div>
+                                </div>
+                            </div>
+                        </div>
 
-                        <!-- Version Control & Documentation -->
-                        <div class="skill-category-title">Version Control & Documentation</div>
-                        <div class="skill-level-item">
-                            <span class="skill-name">SourceTree</span>
-                            <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="100"></div>
-                            </div>
-                        </div>
-                        <div class="skill-level-item">
-                            <span class="skill-name">Confluence Wiki</span>
-                            <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="100"></div>
-                            </div>
-                        </div>
-                        <div class="skill-level-item">
-                            <span class="skill-name">Git</span>
-                            <div class="skill-bar">
-                                <div class="skill-bar-fill" data-width="100"></div>
+                        <!-- UI/UX -->
+                        <div class="skills-column">
+                            <div class="skill-category-title">UI/UX</div>
+                            <div class="skill-level-item">
+                                <span class="skill-name">Game UI Design</span>
+                                <div class="skill-bar">
+                                    <div class="skill-bar-fill" data-width="100"></div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/style.css
+++ b/style.css
@@ -707,6 +707,24 @@ nav {
     border-top: none;
 }
 
+/* Skills Card Wide Layout */
+.card-wide {
+    grid-column: 1 / -1;
+}
+
+/* Skills Grid Layout */
+.skills-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--spacing-md);
+}
+
+.skills-column {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
 /* Skills Bar System */
 .skills-progress-list {
     display: flex;
@@ -721,7 +739,9 @@ nav {
     color: var(--gradient-start);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    margin-bottom: -0.5rem;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid var(--border-color);
 }
 
 .skill-divider {
@@ -1127,6 +1147,12 @@ footer p {
 }
 
 /* ==================== Responsive Design ==================== */
+@media (max-width: 1024px) {
+    .skills-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
 @media (max-width: 768px) {
     .nav-menu {
         position: fixed;
@@ -1178,6 +1204,14 @@ footer p {
     .contact-grid,
     .awards-grid {
         grid-template-columns: 1fr;
+    }
+
+    .skills-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .card-wide {
+        grid-column: 1;
     }
 
     .experience-header {


### PR DESCRIPTION
- Replace old skills categories with new ones: Environment (3), FX (2), Character (2), Animation (2), UI/UX (1)
- Add 3-column grid layout to reduce vertical scrolling
- Make Skills card span full width of resume grid
- Add responsive breakpoints: 2 columns at 1024px, 1 column at 768px