### PR TITLE
Add BRDF simulator link and simplify Skills/Tools section

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,178 +96,58 @@
                     </div>
                 </div>
 
-                <!-- Skills Card -->
-                <div class="card card-wide" id="skillCard">
+                <!-- Skills & Tools Card (Compact) -->
+                <div class="card card-wide">
                     <h3 class="card-title">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <polygon points="12 2 2 7 12 12 22 7 12 2"></polygon>
                             <polyline points="2 17 12 22 22 17"></polyline>
                             <polyline points="2 12 12 17 22 12"></polyline>
                         </svg>
-                        Skills
+                        Skills & Tools
                     </h3>
-                    <div class="skills-grid">
-                        <!-- Environment -->
-                        <div class="skills-column">
-                            <div class="skill-category-title">Environment</div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Level Design</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="100"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">World Building</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="100"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Lighting</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="67"></div>
-                                </div>
+                    <div class="skills-compact">
+                        <div class="skill-group">
+                            <span class="skill-group-title">3D Graphics</span>
+                            <div class="skill-tags">
+                                <span class="tag">3ds Max</span>
+                                <span class="tag">ZBrush</span>
+                                <span class="tag">Blender</span>
+                                <span class="tag">Substance 3D</span>
                             </div>
                         </div>
-
-                        <!-- Character -->
-                        <div class="skills-column">
-                            <div class="skill-category-title">Character</div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Modeling</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="100"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Texturing</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="100"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Rigging</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="67"></div>
-                                </div>
+                        <div class="skill-group">
+                            <span class="skill-group-title">Game Engines</span>
+                            <div class="skill-tags">
+                                <span class="tag">Unity</span>
+                                <span class="tag">Unreal Engine</span>
                             </div>
                         </div>
-
-                        <!-- Animation & FX -->
-                        <div class="skills-column">
-                            <div class="skill-category-title">Animation & FX</div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Keyframe Animation</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="100"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Particle System</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="100"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Shader VFX</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="67"></div>
-                                </div>
+                        <div class="skill-group">
+                            <span class="skill-group-title">Specialties</span>
+                            <div class="skill-tags">
+                                <span class="tag">Level Design</span>
+                                <span class="tag">World Building</span>
+                                <span class="tag">Character Modeling</span>
+                                <span class="tag">Texturing</span>
+                                <span class="tag">Lighting</span>
+                                <span class="tag">VFX</span>
                             </div>
                         </div>
                     </div>
                 </div>
 
-                <!-- Tools Card -->
-                <div class="card card-wide" id="toolsCard">
+                <!-- Research Card - BRDF Simulator -->
+                <div class="card">
                     <h3 class="card-title">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path>
+                            <circle cx="12" cy="12" r="10"></circle>
+                            <polygon points="10 8 16 12 10 16 10 8"></polygon>
                         </svg>
-                        Tools
+                        Research
                     </h3>
-                    <div class="skills-grid">
-                        <!-- Graphics Tools -->
-                        <div class="skills-column">
-                            <div class="skill-category-title">Graphics Tools</div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">3ds Max</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="100"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Photoshop</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="100"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">ZBrush</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="100"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Substance 3D Designer</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="67"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Substance 3D Painter</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="67"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Blender</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="67"></div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Game Engines -->
-                        <div class="skills-column">
-                            <div class="skill-category-title">Game Engines</div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Unity</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="100"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Unreal Engine</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="67"></div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Version Control & Documentation -->
-                        <div class="skills-column">
-                            <div class="skill-category-title">Version Control & Doc</div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">SourceTree</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="100"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Confluence Wiki</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="100"></div>
-                                </div>
-                            </div>
-                            <div class="skill-level-item">
-                                <span class="skill-name">Git</span>
-                                <div class="skill-bar">
-                                    <div class="skill-bar-fill" data-width="100"></div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <p class="card-desc">Disney BRDF Interactive Simulator</p>
+                    <a href="brdf-viewer.html" class="btn btn-secondary" target="_blank">Launch Viewer</a>
                 </div>
 
                 <!-- Download Card -->

--- a/style.css
+++ b/style.css
@@ -743,6 +743,34 @@ nav {
     grid-column: 1 / -1;
 }
 
+/* Skills Compact Layout */
+.skills-compact {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.skill-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.skill-group-title {
+    font-family: 'Pretendard', sans-serif;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.skill-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
 /* Skills Grid Layout */
 .skills-grid {
     display: grid;


### PR DESCRIPTION
- Add Research card with link to BRDF viewer
- Merge Skills and Tools into compact tag-based layout
- Remove verbose skill bars for cleaner appearance