### PR TITLE
Outline Normal Baker v1.4: 면적+각도 가중치 스무딩

### DIFF
--- a/NormalSmoothing.ms
+++ b/NormalSmoothing.ms
@@ -1,6 +1,6 @@
 try(destroyDialog rlSmoothNormalBaker)catch()
 
-rollout rlSmoothNormalBaker "Outline Normal Baker v1.3" width:280
+rollout rlSmoothNormalBaker "Outline Normal Baker v1.4" width:280
 (
     group "Info"
     (
@@ -60,21 +60,61 @@ rollout rlSmoothNormalBaker "Outline Normal Baker v1.3" width:280
         if currentMaps <= 8 then
             meshop.setNumMaps obj 9
         
-        -- Calculate smoothed normals per vertex
+        -- Helper: get triangle area from 3 points
+        fn getTriArea p1 p2 p3 =
+        (
+            local e1 = p2 - p1
+            local e2 = p3 - p1
+            length (cross e1 e2) * 0.5
+        )
+
+        -- Helper: get angle at vertex in a triangle
+        fn getVertAngle pivot p1 p2 =
+        (
+            local e1 = normalize (p1 - pivot)
+            local e2 = normalize (p2 - pivot)
+            local d = dot e1 e2
+            d = amax (-1.0) (amin 1.0 d)
+            acos d
+        )
+
+        -- Calculate smoothed normals per vertex (area + angle weighted)
         local smoothNormals = #()
         for v = 1 to numVerts do
         (
             local vertFaces = meshop.getFacesUsingVert obj v as array
             local avgNormal = [0,0,0]
-            
+            local vertPos = meshop.getVert obj v
+
             for f in vertFaces do
-                avgNormal += getFaceNormal obj f
-            
+            (
+                local faceVerts = getFace obj f
+                local i1 = faceVerts.x as integer
+                local i2 = faceVerts.y as integer
+                local i3 = faceVerts.z as integer
+
+                local p1 = meshop.getVert obj i1
+                local p2 = meshop.getVert obj i2
+                local p3 = meshop.getVert obj i3
+
+                local area = getTriArea p1 p2 p3
+
+                -- Find the angle at the current vertex
+                local angle = 0.0
+                if i1 == v then angle = getVertAngle p1 p2 p3
+                else if i2 == v then angle = getVertAngle p2 p1 p3
+                else if i3 == v then angle = getVertAngle p3 p1 p2
+
+                local weight = area * angle
+                local fn_ = getFaceNormal obj f
+                avgNormal += fn_ * weight
+            )
+
             if length avgNormal > 0 then
                 avgNormal = normalize avgNormal
             else
                 avgNormal = [0,0,1]
-                
+
             smoothNormals[v] = (avgNormal + [1,1,1]) / 2.0
         )
         


### PR DESCRIPTION
## Summary
- Outline Normal Baker v1.3 → v1.4 업데이트
- 뾰족한 모서리에서 아웃라인이 끊어지는 현상 개선
- 노멀 평균 계산에 **면적 × 각도 가중치(Area + Angle Weighting)** 적용

## Changes
- `getTriArea` 헬퍼 추가: 외적 기반 삼각형 면적 계산
- `getVertAngle` 헬퍼 추가: 버텍스 내각 계산 (dot 클램핑으로 acos 안전 처리)
- 기존 균등 평균 → `weight = area × angle` 가중 평균으로 교체

## Test plan
- [ ] 3ds Max에서 스크립트 실행 확인
- [ ] 뾰족한 모서리가 있는 메시에 베이크 후 FBX 익스포트
- [ ] Unity MK Toon 셰이더에서 아웃라인 끊어짐 개선 확인

https://claude.ai/code/session_01QhFU3u4Td6hYcCndoGLhHR