### PR TITLE
3ds Max Scripts 섹션을 컴팩트 리스트형으로 변경

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,89 +412,71 @@
 
             <!-- 3ds Max Scripts -->
             <h3 class="section-subtitle">3ds Max Scripts</h3>
-            <div class="portfolio-grid">
+            <div class="script-list">
                 <!-- UV Exporter -->
-                <div class="portfolio-card portfolio-gradient-5">
-                    <div class="portfolio-content">
-                        <h3>UV Exporter</h3>
-                        <p>선택한 오브젝트들의 UV를 원클릭으로 PNG 익스포트하는 스크립트입니다. 1024 / 2048 / 4096 해상도를 지원하며, 여러 오브젝트 일괄 처리, Unwrap UVW 모디파이어 자동 적용, Render Map 창 자동 닫기 및 익스포트 후 폴더 자동 오픈 기능을 제공합니다.</p>
-                        <div class="portfolio-actions">
-                            <a href="UVWscript.ms" class="portfolio-btn portfolio-btn-primary" download>
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
-                                Download .ms
-                            </a>
-                        </div>
-                    </div>
+                <div class="script-row">
+                    <span class="script-badge">MaxScript</span>
+                    <h4 class="script-title">UV Exporter</h4>
+                    <a href="UVWscript.ms" class="portfolio-btn portfolio-btn-primary" download>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+                        Download .ms
+                    </a>
+                    <p class="script-desc">선택한 오브젝트들의 UV를 원클릭으로 PNG 익스포트하는 스크립트입니다. 1024 / 2048 / 4096 해상도를 지원하며, 여러 오브젝트 일괄 처리, Unwrap UVW 모디파이어 자동 적용, Render Map 창 자동 닫기 및 익스포트 후 폴더 자동 오픈 기능을 제공합니다.</p>
                 </div>
 
                 <!-- Snap UV Vertices -->
-                <div class="portfolio-card portfolio-gradient-3">
-                    <div class="portfolio-content">
-                        <h3>Snap UV Vertices</h3>
-                        <p>Unwrap UVW에서 일정 거리 안의 UV 버텍스들을 평균 위치로 스냅하는 스크립트입니다. 살짝 다른 모델링의 UV 아일랜드를 겹친 뒤 버텍스를 한점으로 정렬할 때 유용합니다.</p>
-                        <div class="portfolio-actions">
-                            <a href="SnapUVVerts.ms" class="portfolio-btn portfolio-btn-primary" download>
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
-                                Download .ms
-                            </a>
-                        </div>
-                    </div>
+                <div class="script-row">
+                    <span class="script-badge">MaxScript</span>
+                    <h4 class="script-title">Snap UV Vertices</h4>
+                    <a href="SnapUVVerts.ms" class="portfolio-btn portfolio-btn-primary" download>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+                        Download .ms
+                    </a>
+                    <p class="script-desc">Unwrap UVW에서 일정 거리 안의 UV 버텍스들을 평균 위치로 스냅하는 스크립트입니다. 살짝 다른 모델링의 UV 아일랜드를 겹친 뒤 버텍스를 한점으로 정렬할 때 유용합니다.</p>
                 </div>
 
                 <!-- Outline Normal Baker -->
-                <div class="portfolio-card portfolio-gradient-6">
-                    <div class="portfolio-content">
-                        <h3>Outline Normal Baker</h3>
-                        <p>MK Toon 쉐이더의 아웃라인을 위해 스무딩된 노말을 UV7 채널에 베이크하는 스크립트입니다. BAKE 버튼 하나로 간편하게 적용할 수 있으며, Unity에서 아웃라인 렌더링 품질을 개선합니다.</p>
-                        <div class="portfolio-actions">
-                            <a href="NormalSmoothing.ms" class="portfolio-btn portfolio-btn-primary" download>
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
-                                Download .ms
-                            </a>
-                        </div>
-                    </div>
+                <div class="script-row">
+                    <span class="script-badge">MaxScript</span>
+                    <h4 class="script-title">Outline Normal Baker</h4>
+                    <a href="NormalSmoothing.ms" class="portfolio-btn portfolio-btn-primary" download>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+                        Download .ms
+                    </a>
+                    <p class="script-desc">MK Toon 쉐이더의 아웃라인을 위해 스무딩된 노말을 UV7 채널에 베이크하는 스크립트입니다. BAKE 버튼 하나로 간편하게 적용할 수 있으며, Unity에서 아웃라인 렌더링 품질을 개선합니다.</p>
                 </div>
 
                 <!-- Remove Collinear Verts -->
-                <div class="portfolio-card portfolio-gradient-4">
-                    <div class="portfolio-content">
-                        <h3>Remove Collinear Verts</h3>
-                        <p>직선 위의 불필요한 중간 버텍스를 자동으로 제거하는 스크립트입니다. 선택한 오브젝트의 지오메트리를 정리하여 폴리곤 수를 최적화합니다.</p>
-                        <div class="portfolio-actions">
-                            <a href="RemoveCollinearVerts.ms" class="portfolio-btn portfolio-btn-primary" download>
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
-                                Download .ms
-                            </a>
-                        </div>
-                    </div>
+                <div class="script-row">
+                    <span class="script-badge">MaxScript</span>
+                    <h4 class="script-title">Remove Collinear Verts</h4>
+                    <a href="RemoveCollinearVerts.ms" class="portfolio-btn portfolio-btn-primary" download>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+                        Download .ms
+                    </a>
+                    <p class="script-desc">직선 위의 불필요한 중간 버텍스를 자동으로 제거하는 스크립트입니다. 선택한 오브젝트의 지오메트리를 정리하여 폴리곤 수를 최적화합니다.</p>
                 </div>
 
                 <!-- Quick Export FBX -->
-                <div class="portfolio-card portfolio-gradient-1">
-                    <div class="portfolio-content">
-                        <h3>Quick Export FBX</h3>
-                        <p>선택한 오브젝트를 원클릭으로 FBX 익스포트하는 스크립트입니다. Reset XForm, 피벗 센터링, 월드 원점 이동, Y-Up 좌표계 변환을 자동 처리하며, 개별/통합 익스포트를 지원합니다.</p>
-                        <div class="portfolio-actions">
-                            <a href="QuickExportFBX.ms" class="portfolio-btn portfolio-btn-primary" download>
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
-                                Download .ms
-                            </a>
-                        </div>
-                    </div>
+                <div class="script-row">
+                    <span class="script-badge">MaxScript</span>
+                    <h4 class="script-title">Quick Export FBX</h4>
+                    <a href="QuickExportFBX.ms" class="portfolio-btn portfolio-btn-primary" download>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+                        Download .ms
+                    </a>
+                    <p class="script-desc">선택한 오브젝트를 원클릭으로 FBX 익스포트하는 스크립트입니다. Reset XForm, 피벗 센터링, 월드 원점 이동, Y-Up 좌표계 변환을 자동 처리하며, 개별/통합 익스포트를 지원합니다.</p>
                 </div>
 
                 <!-- Batch FBX Importer -->
-                <div class="portfolio-card portfolio-gradient-2">
-                    <div class="portfolio-content">
-                        <h3>Batch FBX Importer</h3>
-                        <p>여러 FBX 파일을 한 번에 임포트하는 배치 스크립트입니다. 파일별 새 씬 생성 또는 현재 씬에 병합하는 두 가지 모드를 지원하며, 다중 파일 선택과 성공/실패 카운트 리포트 기능을 제공합니다.</p>
-                        <div class="portfolio-actions">
-                            <a href="BatchFBXImporter.ms" class="portfolio-btn portfolio-btn-primary" download>
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
-                                Download .ms
-                            </a>
-                        </div>
-                    </div>
+                <div class="script-row">
+                    <span class="script-badge">MaxScript</span>
+                    <h4 class="script-title">Batch FBX Importer</h4>
+                    <a href="BatchFBXImporter.ms" class="portfolio-btn portfolio-btn-primary" download>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+                        Download .ms
+                    </a>
+                    <p class="script-desc">여러 FBX 파일을 한 번에 임포트하는 배치 스크립트입니다. 파일별 새 씬 생성 또는 현재 씬에 병합하는 두 가지 모드를 지원하며, 다중 파일 선택과 성공/실패 카운트 리포트 기능을 제공합니다.</p>
                 </div>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -996,6 +996,84 @@ nav {
     color: var(--gradient-start);
 }
 
+/* ==================== 3ds Max Scripts — compact list ==================== */
+.script-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.script-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.8rem 1.1rem;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.script-row:hover {
+    border-color: var(--gradient-start);
+    transform: translateX(3px);
+}
+
+.script-badge {
+    flex-shrink: 0;
+    font-family: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace;
+    font-size: 0.66rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--gradient-start);
+    background: var(--bg-primary);
+    padding: 0.28rem 0.55rem;
+    border-radius: 6px;
+    border: 1px solid var(--border-color);
+    white-space: nowrap;
+}
+
+.script-title {
+    flex-shrink: 0;
+    width: 190px;
+    margin: 0;
+    font-family: 'Pretendard', sans-serif;
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.script-row .portfolio-btn {
+    flex-shrink: 0;
+    padding: 0.5rem 0.9rem;
+    font-size: 0.82rem;
+}
+
+.script-desc {
+    flex: 1;
+    min-width: 0;
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 1.55;
+    color: var(--text-secondary);
+}
+
+@media (max-width: 768px) {
+    .script-row {
+        flex-wrap: wrap;
+        gap: 0.5rem 0.7rem;
+    }
+
+    .script-title {
+        width: auto;
+    }
+
+    .script-desc {
+        flex-basis: 100%;
+        order: 10;
+    }
+}
+
 .skill-tags {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## 무엇을

`3ds Max Scripts` 섹션이 Portfolio와 동일한 큰 그라데이션 카드(`.portfolio-card`)를 6개 사용해 가로 폭을 너무 많이 차지했습니다. 이를 **컴팩트한 가로 리스트 행**으로 변경했습니다.

## 변경

- `.portfolio-grid` + `.portfolio-card` × 6 → `.script-list` + `.script-row` × 6
- 각 행 레이아웃: `[MaxScript 뱃지] [제목] [Download .ms 버튼] [설명]`
- 뱃지·제목 고정폭 → **다운로드 버튼이 세로로 정렬**, 설명은 남는 폭을 채움
- 다운로드 버튼은 기존 `.portfolio-btn` 재사용(행 안에선 패딩만 축소)
- 모바일(≤768px)에선 설명이 아래줄로 자동 줄바꿈되는 반응형 처리
- 라이트/다크 테마 변수(`--card-bg`, `--gradient-start` 등) 사용으로 양쪽 대응

## 비고

콘텐츠(제목·설명·다운로드 링크)는 그대로 유지, 표현 방식만 변경했습니다.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYChLeb1Z9HKsCCiSmLSA3)_