### PR TITLE
이력서: 석사 졸업예정 표기 + 경기콘텐츠진흥원 멘토링 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,8 +89,8 @@
                     <div class="resume-item">
                         <img src="hongik_emblem_black.png" alt="홍익대학교" class="school-logo">
                         <h4>홍익대학교 영상커뮤니케이션대학원<br>게임콘텐츠과</h4>
-                        <p class="resume-period">2024.03 - 현재</p>
-                        <p class="resume-desc">석사과정</p>
+                        <p class="resume-period">2024.03 - 2026.08</p>
+                        <p class="resume-desc">석사 졸업예정</p>
                     </div>
                     <div class="resume-item">
                         <img src="hongik_emblem_black.png" alt="홍익대학교" class="school-logo">
@@ -235,6 +235,11 @@
                         </span>
                     </div>
                     <div class="experience-list">
+                        <div class="resume-item">
+                            <h4>경기콘텐츠진흥원</h4>
+                            <p class="resume-period">2026.05 - 2026.10</p>
+                            <p class="resume-desc">멘토: 인디게임팀 대상 아트 전반 멘토링</p>
+                        </div>
                         <div class="resume-item">
                             <img src="ggm_logo.png" alt="경기게임마이스터고등학교" class="school-logo">
                             <h4>경기게임마이스터고등학교</h4>


### PR DESCRIPTION
## 변경

이력서 콘텐츠 업데이트 (`index.html`).

### Education
- 홍익대학교 영상커뮤니케이션대학원 게임콘텐츠과
  - 기간: `2024.03 - 현재` → `2024.03 - 2026.08`
  - 표기: `석사과정` → `석사 졸업예정`

### 강의 · 멘토링
- **경기콘텐츠진흥원** 항목 추가 (목록 최상단, 가장 최근)
  - 기간: `2026.05 - 2026.10`
  - 내용: 멘토 — 인디게임팀 대상 아트 전반 멘토링

## 비고
- 석사 정식 학위명(예: 영상학석사)은 공식 출처에서 확정하지 못해, 사실관계상 안전한 "석사 졸업예정"으로 표기했습니다. 추후 확인되면 괄호로 학위명 보강 가능.
- 경기콘텐츠진흥원은 저장소에 로고 이미지가 없어 텍스트 항목으로 추가했습니다(로고 주시면 적용 가능).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYChLeb1Z9HKsCCiSmLSA3)_