### PR TITLE
이력서: 경기게임마이스터고 강의 설명 간결화

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@
                             <img src="ggm_logo.png" alt="경기게임마이스터고등학교" class="school-logo">
                             <h4>경기게임마이스터고등학교</h4>
                             <p class="resume-period">2025.08 - 현재</p>
-                            <p class="resume-desc">산학교사: 게임디자인 (3D 모델링, 텍스처링, Unity, Blender, ZBrush, 포트폴리오 지도)</p>
+                            <p class="resume-desc">산학교사: 미술 기초 ~ 포트폴리오 지도</p>
                         </div>
                         <div class="resume-item">
                             <img src="ck_logo.jpg" alt="청강문화산업대학" class="school-logo">


### PR DESCRIPTION
## 변경

이력서 **강의 · 멘토링**의 경기게임마이스터고등학교 설명 문구 수정.

- 기존: `산학교사: 게임디자인 (3D 모델링, 텍스처링, Unity, Blender, ZBrush, 포트폴리오 지도)`
- 변경: `산학교사: 미술 기초 ~ 포트폴리오 지도`

실제로 미술 기초부터 포트폴리오 지도까지 폭넓게 가르치는 점을 반영해 간결하게 정리했습니다.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYChLeb1Z9HKsCCiSmLSA3)_