### PR TITLE
Unify Awards / Research Papers / Web·App into row-list layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,48 +267,73 @@
 
             <!-- Awards Section -->
             <h3 class="section-subtitle">Awards</h3>
-            <div class="awards-grid">
-                <div class="award-item">
-                    <h4>홍익대학교 총장 표창장</h4>
-                    <p class="award-project">학술대회 우수논문 수상을 통한 본교 명예 선양 (총장 박상주)</p>
-                    <span class="award-date">2026.02</span>
+            <div class="script-list">
+                <div class="script-row info-row">
+                    <span class="script-badge">2026.02</span>
+                    <div class="info-main">
+                        <h4>홍익대학교 총장 표창장</h4>
+                        <p>학술대회 우수논문 수상을 통한 본교 명예 선양 (총장 박상주)</p>
+                    </div>
                 </div>
-                <div class="award-item">
-                    <h4>2025 한국게임학회 추계학술대회 우수논문상</h4>
-                    <p class="award-project">3DGS기반 게임 제작 교육의 실행 가능성 탐색: 게임 특성화 고등학교 사례 연구</p>
-                    <span class="award-date">2025.11</span>
+                <div class="script-row info-row">
+                    <span class="script-badge">2025.11</span>
+                    <div class="info-main">
+                        <h4>2025 한국게임학회 추계학술대회 우수논문상</h4>
+                        <p>3DGS기반 게임 제작 교육의 실행 가능성 탐색: 게임 특성화 고등학교 사례 연구</p>
+                    </div>
                 </div>
-                <div class="award-item">
-                    <h4>BIC 2018 EXCELLENCE IN CASUAL</h4>
-                    <p class="award-project">Colorzzle</p>
-                    <span class="award-date">2018.09</span>
+                <div class="script-row info-row">
+                    <span class="script-badge">2018.09</span>
+                    <div class="info-main">
+                        <h4>BIC 2018 EXCELLENCE IN CASUAL</h4>
+                        <p>Colorzzle</p>
+                    </div>
                 </div>
-                <div class="award-item">
-                    <h4>STEP UP! PROJECT GRAND PRIZE</h4>
-                    <p class="award-project">Color Puzzle (성남산업진흥재단)</p>
-                    <span class="award-date">2017.09</span>
+                <div class="script-row info-row">
+                    <span class="script-badge">2017.09</span>
+                    <div class="info-main">
+                        <h4>STEP UP! PROJECT GRAND PRIZE</h4>
+                        <p>Color Puzzle (성남산업진흥재단)</p>
+                    </div>
                 </div>
             </div>
 
             <!-- Research Papers Section -->
             <h3 class="section-subtitle">Research Papers</h3>
-            <div class="awards-grid">
-                <div class="award-item">
-                    <h4>DiGRA-K (국제디지털게임연구학회 한국지회) 학술지 게재</h4>
-                    <p class="award-project">색채 기반 모바일 퍼즐게임 개발과정 연구: Practice-Based Research를 통한 게임 메커니즘 구축 사례</p>
-                    <p class="award-meta">《디지털게임연구》 2025년 겨울호 (제1권 2호), pp.13-36</p>
-                    <p class="award-meta"><a href="https://doi.org/10.64145/kjdgs.2025.1.2.13" target="_blank" rel="noopener">DOI: 10.64145/kjdgs.2025.1.2.13</a></p>
-                    <span class="award-date">2025.12</span>
+            <div class="script-list">
+                <div class="script-row info-row">
+                    <span class="script-badge">2025.12</span>
+                    <div class="info-main">
+                        <h4>DiGRA-K (국제디지털게임연구학회 한국지회) 학술지 게재</h4>
+                        <p>색채 기반 모바일 퍼즐게임 개발과정 연구: Practice-Based Research를 통한 게임 메커니즘 구축 사례</p>
+                        <p class="info-meta">《디지털게임연구》 2025년 겨울호 (제1권 2호), pp.13-36</p>
+                    </div>
+                    <div class="info-actions">
+                        <a href="https://doi.org/10.64145/kjdgs.2025.1.2.13" class="portfolio-btn portfolio-btn-primary" target="_blank" rel="noopener">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
+                            DOI
+                        </a>
+                    </div>
                 </div>
-                <div class="award-item">
-                    <h4>2025 한국게임학회 추계 학술대회 논문 수록 <span class="award-badge">⭐ 우수논문선정</span></h4>
-                    <p class="award-project">3DGS기반 게임 제작 교육의 실행 가능성 탐색: 게임 특성화 고등학교 사례 연구</p>
-                    <span class="award-date">2025.11</span>
+                <div class="script-row info-row">
+                    <span class="script-badge">2025.11</span>
+                    <div class="info-main">
+                        <h4>2025 한국게임학회 추계 학술대회 논문 수록 <span class="award-badge">⭐ 우수논문선정</span></h4>
+                        <p>3DGS기반 게임 제작 교육의 실행 가능성 탐색: 게임 특성화 고등학교 사례 연구</p>
+                    </div>
                 </div>
-                <div class="award-item">
-                    <h4>2024 한국게임학회 추계 학술대회 논문 수록</h4>
-                    <p class="award-project">Photogrammetry와 NeRF의 비교분석을 통한 실사 오브젝트 제작 방식의 미래 방향성 제안</p>
-                    <span class="award-date">2024.11</span>
+                <div class="script-row info-row">
+                    <span class="script-badge">2024.11</span>
+                    <div class="info-main">
+                        <h4>2024 한국게임학회 추계 학술대회 논문 수록</h4>
+                        <p>Photogrammetry와 NeRF의 비교분석을 통한 실사 오브젝트 제작 방식의 미래 방향성 제안</p>
+                    </div>
+                    <div class="info-actions">
+                        <a href="Kim_SoYeon_NeRF_Research_2024.pdf" class="portfolio-btn portfolio-btn-primary" target="_blank">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline></svg>
+                            PDF
+                        </a>
+                    </div>
                 </div>
             </div>
         </div>
@@ -352,82 +377,87 @@
 
             <!-- Web / App -->
             <h3 class="section-subtitle">Web / App</h3>
-            <div class="portfolio-grid">
+            <div class="script-list">
                 <!-- Portfolio Website -->
-                <div class="portfolio-card portfolio-gradient-1">
-                    <div class="portfolio-content">
-                        <h3>Portfolio Website</h3>
+                <div class="script-row info-row">
+                    <span class="script-badge">Web</span>
+                    <div class="info-main">
+                        <h4>Portfolio Website</h4>
                         <p>이 포트폴리오 사이트 자체를 에이전틱 코딩으로 제작했습니다.</p>
-                        <div class="portfolio-actions">
-                            <a href="https://studioaryeon.com/" class="portfolio-btn portfolio-btn-primary" target="_blank">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
-                                Visit Site
-                            </a>
-                        </div>
+                    </div>
+                    <div class="info-actions">
+                        <a href="https://studioaryeon.com/" class="portfolio-btn portfolio-btn-primary" target="_blank">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
+                            Visit Site
+                        </a>
                     </div>
                 </div>
 
                 <!-- BRDF Simulator -->
-                <div class="portfolio-card portfolio-gradient-2">
-                    <div class="portfolio-content">
-                        <h3>BRDF Simulator</h3>
+                <div class="script-row info-row">
+                    <span class="script-badge">WebGL</span>
+                    <div class="info-main">
+                        <h4>BRDF Simulator</h4>
                         <p>Disney BRDF 모델 기반 인터랙티브 시뮬레이터입니다.</p>
-                        <div class="portfolio-actions">
-                            <a href="https://studioaryeon.com/brdf-viewer.html" class="portfolio-btn portfolio-btn-primary" target="_blank">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
-                                Launch Viewer
-                            </a>
-                        </div>
+                    </div>
+                    <div class="info-actions">
+                        <a href="https://studioaryeon.com/brdf-viewer.html" class="portfolio-btn portfolio-btn-primary" target="_blank">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
+                            Launch Viewer
+                        </a>
                     </div>
                 </div>
 
                 <!-- Interior Mapping -->
-                <div class="portfolio-card portfolio-gradient-5">
-                    <div class="portfolio-content">
-                        <h3>Interior Mapping</h3>
+                <div class="script-row info-row">
+                    <span class="script-badge">WebGL</span>
+                    <div class="info-main">
+                        <h4>Interior Mapping</h4>
                         <p>평면 폴리곤 한 장에 프래그먼트 셰이더로 창문 너머 방 내부를 그리는 인터랙티브 WebGL 데모입니다. 해석적 ray-box 교차로 패럴랙스를 만들고, 슬랩/아틀라스 텍스처 샘플링 위에 유리 프레넬 반사·먼지 레이어를 얹었습니다.</p>
-                        <div class="portfolio-actions">
-                            <a href="https://studioaryeon.com/interior-mapping.html" class="portfolio-btn portfolio-btn-primary" target="_blank">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
-                                Launch Demo
-                            </a>
-                        </div>
+                    </div>
+                    <div class="info-actions">
+                        <a href="https://studioaryeon.com/interior-mapping.html" class="portfolio-btn portfolio-btn-primary" target="_blank">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
+                            Launch Demo
+                        </a>
                     </div>
                 </div>
 
                 <!-- Pixel Pow -->
-                <div class="portfolio-card portfolio-gradient-3">
-                    <div class="portfolio-content">
-                        <h3>Pixel Pow</h3>
+                <div class="script-row info-row">
+                    <span class="script-badge">Web · iOS</span>
+                    <div class="info-main">
+                        <h4>Pixel Pow</h4>
                         <p>이미지에서 컬러를 추출하는 앱입니다. iOS와 웹 버전을 제공합니다.</p>
-                        <div class="portfolio-actions">
-                            <a href="https://pixel-pow.com/" class="portfolio-btn portfolio-btn-primary" target="_blank">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
-                                Web App
-                            </a>
-                            <a href="https://apps.apple.com/kr/app/pixel-pow/id6758751368" class="portfolio-btn portfolio-btn-secondary" target="_blank">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
-                                App Store
-                            </a>
-                        </div>
+                    </div>
+                    <div class="info-actions">
+                        <a href="https://pixel-pow.com/" class="portfolio-btn portfolio-btn-primary" target="_blank">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
+                            Web App
+                        </a>
+                        <a href="https://apps.apple.com/kr/app/pixel-pow/id6758751368" class="portfolio-btn portfolio-btn-secondary" target="_blank">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
+                            App Store
+                        </a>
                     </div>
                 </div>
 
                 <!-- Light of Ruins -->
-                <div class="portfolio-card portfolio-gradient-4">
-                    <div class="portfolio-content">
-                        <h3>폐허의 불빛 — Light of Ruins</h3>
+                <div class="script-row info-row">
+                    <span class="script-badge">Web Game</span>
+                    <div class="info-main">
+                        <h4>폐허의 불빛 — Light of Ruins</h4>
                         <p>좀비 아포칼립스 생존 마을을 30일간 운영하는 텍스트 기반 웹게임입니다. 식량·체력·사기 3축과 분기 선택에 따라 5가지 엔딩으로 갈립니다. 홍익대학교 대학원 게임 디자인 과제 『폐허의 불빛 v1.2』의 웹 구현체입니다.</p>
-                        <div class="portfolio-actions">
-                            <a href="https://studioaryeon.com/light-of-ruins/" class="portfolio-btn portfolio-btn-primary" target="_blank">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>
-                                Play Game
-                            </a>
-                            <a href="https://github.com/Aryeon0228/light-of-ruins" class="portfolio-btn portfolio-btn-secondary" target="_blank">
-                                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
-                                GitHub
-                            </a>
-                        </div>
+                    </div>
+                    <div class="info-actions">
+                        <a href="https://studioaryeon.com/light-of-ruins/" class="portfolio-btn portfolio-btn-primary" target="_blank">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+                            Play Game
+                        </a>
+                        <a href="https://github.com/Aryeon0228/light-of-ruins" class="portfolio-btn portfolio-btn-secondary" target="_blank">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+                            GitHub
+                        </a>
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -445,7 +445,7 @@ const observer = new IntersectionObserver((entries) => {
 
 // Observe all cards and sections for animation
 document.addEventListener('DOMContentLoaded', () => {
-    const animatedElements = document.querySelectorAll('.card, .section-title, .portfolio-card, .experience-item, .award-item');
+    const animatedElements = document.querySelectorAll('.card, .section-title, .portfolio-card, .experience-item, .award-item, .script-row');
 
     animatedElements.forEach(el => {
         el.style.opacity = '0';

--- a/style.css
+++ b/style.css
@@ -1074,6 +1074,70 @@ nav {
     }
 }
 
+/* Info Row (Awards / Research Papers / Web·App) — shares the script-row look */
+.info-row .script-badge {
+    align-self: flex-start;
+    margin-top: 0.15rem;
+}
+
+.info-main {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.info-main h4 {
+    margin: 0;
+    font-family: 'Pretendard', sans-serif;
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.4;
+    color: var(--text-primary);
+}
+
+.info-main p {
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 1.55;
+    color: var(--text-secondary);
+}
+
+.info-main .info-meta {
+    font-size: 0.78rem;
+    opacity: 0.85;
+}
+
+.info-main .info-meta a {
+    color: var(--gradient-start);
+    text-decoration: none;
+}
+
+.info-main .info-meta a:hover {
+    text-decoration: underline;
+}
+
+.info-actions {
+    flex-shrink: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-self: center;
+}
+
+.info-actions .portfolio-btn {
+    padding: 0.5rem 0.9rem;
+    font-size: 0.82rem;
+}
+
+@media (max-width: 768px) {
+    .info-actions {
+        flex-basis: 100%;
+        align-self: stretch;
+    }
+}
+
 .skill-tags {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## 요약

Awards · Research Papers · Web/App 세 섹션을 **3ds Max Scripts와 동일한 가로 행(row) 리스트 스타일**로 통일했습니다.

- 기존: Awards/Papers는 `awards-grid` 박스 카드, Web/App은 `portfolio-grid` 큰 카드 — 섹션마다 톤이 제각각
- 변경: 모두 `script-row` 룩(배지 + 테두리 + hover) 재사용 → **[날짜·카테고리 배지] + [제목/설명 세로 스택] + [액션 버튼]** 구조

## 세부

- **Awards** — 날짜를 모노 배지로, 제목+상세를 행으로
- **Research Papers** — 날짜 배지 + 게재 정보(meta) + 액션 버튼
  - DiGRA-K 논문 → `DOI` 버튼
  - 2024 NeRF 논문 → 레포에 있는 `Kim_SoYeon_NeRF_Research_2024.pdf` 다운로드 버튼 신규 추가
  - 우수논문선정 배지(⭐)는 그대로 유지
- **Web / App** — 카드 → 행 리스트. 카테고리 배지(Web / WebGL / Web·iOS / Web Game) 추가, Launch·스토어 버튼은 우측 액션으로 유지
- 긴 한글 제목에 맞춰 제목/설명을 세로 스택으로 두는 `.info-main` / `.info-actions` 클래스 신규 (Max Scripts의 `.script-row` 컨테이너·`.script-badge`는 그대로 재사용)
- 스크롤 등장(fade-in) 효과 유지를 위해 `.script-row`를 reveal 대상에 추가
- 미사용이 된 `.awards-grid` / `.award-item` CSS는 향후 재사용 여지 두고 보존 (무해)

## 반응형

모바일(≤768px)에서는 액션 버튼이 행 아래로 풀폭 정렬되도록 처리.

https://claude.ai/code/session_01S4SVukj8bG7D9qpNA7XQkX

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4SVukj8bG7D9qpNA7XQkX)_