### PR TITLE
Polish: stack action buttons + restructure Skills & Tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,31 +119,46 @@
                         Skills & Tools
                     </h3>
                     <div class="skills-compact">
-                        <div class="skill-group">
-                            <span class="skill-group-title">3D Graphics</span>
-                            <div class="skill-tags">
-                                <span class="tag">3ds Max</span>
-                                <span class="tag">ZBrush</span>
-                                <span class="tag">Blender</span>
-                                <span class="tag">Substance 3D</span>
+                        <!-- Tools (Software) -->
+                        <div class="skill-section">
+                            <span class="skill-section-title">Tools</span>
+                            <div class="skill-group">
+                                <span class="skill-group-title">3D / DCC</span>
+                                <div class="skill-tags">
+                                    <span class="tag">3ds Max</span>
+                                    <span class="tag">ZBrush</span>
+                                    <span class="tag">Blender</span>
+                                    <span class="tag">RizomUV</span>
+                                </div>
+                            </div>
+                            <div class="skill-group">
+                                <span class="skill-group-title">Texturing &amp; 2D</span>
+                                <div class="skill-tags">
+                                    <span class="tag">Substance 3D Painter</span>
+                                    <span class="tag">Substance 3D Designer</span>
+                                    <span class="tag">Photoshop</span>
+                                </div>
+                            </div>
+                            <div class="skill-group">
+                                <span class="skill-group-title">Game Engines</span>
+                                <div class="skill-tags">
+                                    <span class="tag">Unity</span>
+                                    <span class="tag">Unreal Engine</span>
+                                </div>
                             </div>
                         </div>
-                        <div class="skill-group">
-                            <span class="skill-group-title">Game Engines</span>
-                            <div class="skill-tags">
-                                <span class="tag">Unity</span>
-                                <span class="tag">Unreal Engine</span>
-                            </div>
-                        </div>
-                        <div class="skill-group">
-                            <span class="skill-group-title">Specialties</span>
-                            <div class="skill-tags">
-                                <span class="tag">Level Design</span>
-                                <span class="tag">World Building</span>
-                                <span class="tag">Character Modeling</span>
-                                <span class="tag">Texturing</span>
-                                <span class="tag">Lighting</span>
-                                <span class="tag">VFX</span>
+                        <!-- Skills (Specialties) -->
+                        <div class="skill-section">
+                            <span class="skill-section-title">Skills</span>
+                            <div class="skill-group">
+                                <div class="skill-tags">
+                                    <span class="tag">Level Design</span>
+                                    <span class="tag">World Building</span>
+                                    <span class="tag">Character Modeling</span>
+                                    <span class="tag">Texturing</span>
+                                    <span class="tag">Lighting</span>
+                                    <span class="tag">VFX</span>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/style.css
+++ b/style.css
@@ -968,6 +968,22 @@ nav {
     letter-spacing: 0.1em;
 }
 
+.skill-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.skill-section-title {
+    font-family: 'Pretendard', sans-serif;
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    letter-spacing: 0.03em;
+    padding-bottom: 0.4rem;
+    border-bottom: 1.5px solid var(--border-color);
+}
+
 /* Experience Category Divider & Title */
 .experience-category {
     margin-top: 1.5rem;

--- a/style.css
+++ b/style.css
@@ -1121,12 +1121,15 @@ nav {
 .info-actions {
     flex-shrink: 0;
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
+    align-items: stretch;
     gap: 0.5rem;
     align-self: center;
+    width: 160px;
 }
 
 .info-actions .portfolio-btn {
+    justify-content: center;
     padding: 0.5rem 0.9rem;
     font-size: 0.82rem;
 }
@@ -1135,6 +1138,7 @@ nav {
     .info-actions {
         flex-basis: 100%;
         align-self: stretch;
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
두 가지 디자인 정리를 담았습니다.

## 1. 액션 버튼 세로 정렬
- `.info-actions`를 우측 **고정폭(160px) 세로 컬럼**으로 → 버튼이 세로로 쌓이고 폭 통일, 깔끔하게 우측 정렬
- 라벨·아이콘 가운데 정렬, 단일 버튼 행(DOI/PDF)도 동일 정렬
- 모바일(≤768px)은 풀폭 세로 스택

## 2. Skills & Tools 재구성
- **Tools / Skills** 두 섹션으로 명확히 분리 (구분선 헤더)
  - Tools → `3D / DCC` · `Texturing & 2D` · `Game Engines` 하위 분류
  - Skills → Level Design, World Building, Character Modeling, Texturing, Lighting, VFX
- 빠져있던 툴 추가: **Photoshop, Substance 3D Painter, Substance 3D Designer, RizomUV**
- 기존 뭉뚱그린 `Substance 3D` 태그는 Painter / Designer로 분리

> 참고: "라이좀"은 **RizomUV**(UV 언랩 툴)로 해석했어요. 다른 툴이면 알려주세요. 추가로 빠진 툴 있으면 더 채울게요.

https://claude.ai/code/session_01S4SVukj8bG7D9qpNA7XQkX