### PR TITLE
Polish info-rows: papers structure + fixed-width badge alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,9 +319,12 @@
                 <div class="script-row info-row">
                     <span class="script-badge">2025.12</span>
                     <div class="info-main">
-                        <h4>DiGRA-K (국제디지털게임연구학회 한국지회) 학술지 게재</h4>
-                        <p>색채 기반 모바일 퍼즐게임 개발과정 연구: Practice-Based Research를 통한 게임 메커니즘 구축 사례</p>
-                        <p class="info-meta">《디지털게임연구》 2025년 겨울호 (제1권 2호), pp.13-36</p>
+                        <h4>색채 기반 모바일 퍼즐게임 개발과정 연구: Practice-Based Research를 통한 게임 메커니즘 구축 사례 <span class="award-badge">학술지</span></h4>
+                        <p class="info-venue">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg>
+                            DiGRA-K · 국제디지털게임연구학회 한국지회
+                        </p>
+                        <p class="info-meta">《디지털게임연구》 2025년 겨울호 (제1권 2호), pp.13–36</p>
                     </div>
                     <div class="info-actions">
                         <a href="https://doi.org/10.64145/kjdgs.2025.1.2.13" class="portfolio-btn portfolio-btn-primary" target="_blank" rel="noopener">
@@ -333,15 +336,21 @@
                 <div class="script-row info-row">
                     <span class="script-badge">2025.11</span>
                     <div class="info-main">
-                        <h4>2025 한국게임학회 추계 학술대회 논문 수록 <span class="award-badge">⭐ 우수논문선정</span></h4>
-                        <p>3DGS기반 게임 제작 교육의 실행 가능성 탐색: 게임 특성화 고등학교 사례 연구</p>
+                        <h4>3DGS기반 게임 제작 교육의 실행 가능성 탐색: 게임 특성화 고등학교 사례 연구 <span class="award-badge">⭐ 우수논문</span></h4>
+                        <p class="info-venue">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg>
+                            한국게임학회 · 2025 추계 학술대회
+                        </p>
                     </div>
                 </div>
                 <div class="script-row info-row">
                     <span class="script-badge">2024.11</span>
                     <div class="info-main">
-                        <h4>2024 한국게임학회 추계 학술대회 논문 수록</h4>
-                        <p>Photogrammetry와 NeRF의 비교분석을 통한 실사 오브젝트 제작 방식의 미래 방향성 제안</p>
+                        <h4>Photogrammetry와 NeRF의 비교분석을 통한 실사 오브젝트 제작 방식의 미래 방향성 제안 <span class="award-badge">학술대회</span></h4>
+                        <p class="info-venue">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg>
+                            한국게임학회 · 2024 추계 학술대회
+                        </p>
                     </div>
                     <div class="info-actions">
                         <a href="Kim_SoYeon_NeRF_Research_2024.pdf" class="portfolio-btn portfolio-btn-primary" target="_blank">

--- a/style.css
+++ b/style.css
@@ -1120,6 +1120,21 @@ nav {
     color: var(--text-secondary);
 }
 
+.info-main .info-venue {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--gradient-start);
+}
+
+.info-main .info-venue svg {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+}
+
 .info-main .info-meta {
     font-size: 0.78rem;
     opacity: 0.85;

--- a/style.css
+++ b/style.css
@@ -1094,6 +1094,10 @@ nav {
 .info-row .script-badge {
     align-self: flex-start;
     margin-top: 0.15rem;
+    width: 96px;
+    display: inline-flex;
+    justify-content: center;
+    text-align: center;
 }
 
 .info-main {


### PR DESCRIPTION
진행 중인 info-row 정리 작업 두 가지를 담았습니다.

## 1. Research Papers — 날짜 / 제목 / 학회 분류 명확화
- **날짜** → 좌측 배지 / **제목** → h4 강조(실제 논문 제목으로 교체) / **학회·학술지** → 아이콘+액센트색 venue 라인으로 분리
- 유형 칩 추가: `학술지` / `학술대회` / `⭐우수논문`
- 게재 상세(권·호·페이지) meta 라인, DOI/PDF 버튼 유지

## 2. info-row 배지 정렬 고정
- Web/App 카테고리 배지(Web · WebGL · Web·iOS · Web Game)가 길이가 달라 제목 시작점이 들쭉날쭉하던 문제
- `.info-row .script-badge`를 **고정폭 96px 가운데 정렬** 컬럼으로 → 제목이 한 줄로 딱 맞게 정렬 (Awards·Papers 날짜 배지에도 동일 적용되어 전체 일관)

https://claude.ai/code/session_01S4SVukj8bG7D9qpNA7XQkX