### PR TITLE
Add line breaks to Interior Mapping & Light of Ruins descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@
                     <span class="script-badge">WebGL</span>
                     <div class="info-main">
                         <h4>Interior Mapping</h4>
-                        <p>평면 폴리곤 한 장에 프래그먼트 셰이더로 창문 너머 방 내부를 그리는 인터랙티브 WebGL 데모입니다. 해석적 ray-box 교차로 패럴랙스를 만들고, 슬랩/아틀라스 텍스처 샘플링 위에 유리 프레넬 반사·먼지 레이어를 얹었습니다.</p>
+                        <p>평면 폴리곤 한 장에 프래그먼트 셰이더로 창문 너머 방 내부를 그리는 인터랙티브 WebGL 데모입니다.<br>해석적 ray-box 교차로 패럴랙스를 만들고, 슬랩/아틀라스 텍스처 샘플링 위에 유리 프레넬 반사·먼지 레이어를 얹었습니다.</p>
                     </div>
                     <div class="info-actions">
                         <a href="https://studioaryeon.com/interior-mapping.html" class="portfolio-btn portfolio-btn-primary" target="_blank">
@@ -471,7 +471,7 @@
                     <span class="script-badge">Web Game</span>
                     <div class="info-main">
                         <h4>폐허의 불빛 — Light of Ruins</h4>
-                        <p>좀비 아포칼립스 생존 마을을 30일간 운영하는 텍스트 기반 웹게임입니다. 식량·체력·사기 3축과 분기 선택에 따라 5가지 엔딩으로 갈립니다. 홍익대학교 대학원 게임 디자인 과제 『폐허의 불빛 v1.2』의 웹 구현체입니다.</p>
+                        <p>좀비 아포칼립스 생존 마을을 30일간 운영하는 텍스트 기반 웹게임입니다. 식량·체력·사기 3축과 분기 선택에 따라 5가지 엔딩으로 갈립니다.<br>홍익대학교 대학원 게임 디자인 과제 『폐허의 불빛 v1.2』의 웹 구현체입니다.</p>
                     </div>
                     <div class="info-actions">
                         <a href="https://studioaryeon.com/light-of-ruins/" class="portfolio-btn portfolio-btn-primary" target="_blank">


### PR DESCRIPTION
## 요약

Agentic Coding 섹션 설명문에 줄바꿈(`<br>`)을 넣어 가독성을 높이고 웹에서 자연스럽게 줄이 나뉘도록 했습니다.

- **Interior Mapping** — "…데모입니다." 뒤 줄바꿈
- **폐허의 불빛 (Light of Ruins)** — "…갈립니다." 뒤 줄바꿈

설명 텍스트엔 line-clamp/ellipsis 같은 잘림 처리가 없어 내용이 잘리지 않고 전부 표시됩니다.

https://claude.ai/code/session_01S4SVukj8bG7D9qpNA7XQkX

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4SVukj8bG7D9qpNA7XQkX)_