### PR TITLE
Resume/Experience fonts + logos + 3DGS paper badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@
                 <div class="script-row info-row">
                     <span class="script-badge">2025.11</span>
                     <div class="info-main">
-                        <h4>3DGS기반 게임 제작 교육의 실행 가능성 탐색: 게임 특성화 고등학교 사례 연구 <span class="award-badge">⭐ 우수논문</span></h4>
+                        <h4>3DGS기반 게임 제작 교육의 실행 가능성 탐색: 게임 특성화 고등학교 사례 연구 <span class="award-badge">⭐ 우수논문</span> <span class="award-badge">학술대회</span></h4>
                         <p class="info-venue">
                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg>
                             한국게임학회 · 2025 추계 학술대회

--- a/style.css
+++ b/style.css
@@ -733,13 +733,13 @@ nav {
     width: 120px;
     height: 120px;
     object-fit: contain;
-    opacity: 0.1;
+    opacity: 0.22;
     pointer-events: none;
 }
 
 .resume-item h4 {
     font-family: 'Pretendard', sans-serif;
-    font-size: 1.125rem;
+    font-size: 1rem;
     font-weight: 600;
     margin-bottom: 0.5rem;
     color: var(--text-primary);
@@ -748,19 +748,20 @@ nav {
 .resume-period {
     color: var(--gradient-start);
     font-weight: 600;
-    font-size: 0.875rem;
+    font-size: 0.8rem;
     margin-bottom: 0.5rem;
 }
 
 .resume-role {
-    font-size: 0.8rem;
+    font-size: 0.78rem;
     font-weight: 500;
     color: var(--text-secondary);
 }
 
 .resume-desc {
     color: var(--text-secondary);
-    line-height: 1.6;
+    font-size: 0.85rem;
+    line-height: 1.55;
     word-break: keep-all;
 }
 


### PR DESCRIPTION
## 요약

### 1. Resume/Experience/Education 폰트 → Awards 톤
- `.resume-item h4` 1.125rem → **1rem**
- `.resume-desc` 본문 18px 상속 → **0.85rem** (가장 큰 변화)
- `.resume-period` 0.875rem → **0.8rem**, `.resume-role` 0.8rem → **0.78rem**
- Education·Experience·강의/멘토링이 같은 클래스라 한 번에 통일

### 2. 로고 가시성
- `.school-logo` opacity 0.1 → **0.22**

### 3. 3DGS 논문 배지 보강
- 우수논문 수상 논문도 학술대회 발표작이므로 `⭐ 우수논문` 옆에 **학술대회** 배지 추가

https://claude.ai/code/session_01S4SVukj8bG7D9qpNA7XQkX