### PR TITLE
Shrink Hongik & Chungkang watermark logos to 50%

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,13 +90,13 @@
                         Education
                     </h3>
                     <div class="resume-item">
-                        <img src="hongik_emblem_black.png" alt="홍익대학교" class="school-logo">
+                        <img src="hongik_emblem_black.png" alt="홍익대학교" class="school-logo school-logo-sm">
                         <h4>홍익대학교 영상커뮤니케이션대학원<br>게임콘텐츠과</h4>
                         <p class="resume-period">2024.03 - 2026.08</p>
                         <p class="resume-desc">석사 졸업예정</p>
                     </div>
                     <div class="resume-item">
-                        <img src="hongik_emblem_black.png" alt="홍익대학교" class="school-logo">
+                        <img src="hongik_emblem_black.png" alt="홍익대학교" class="school-logo school-logo-sm">
                         <h4>홍익대학교 조형학부 애니메이션과</h4>
                         <p class="resume-period">2003.03 - 2007.02</p>
                         <p class="resume-desc">미술학사</p>
@@ -265,13 +265,13 @@
                             <p class="resume-desc">산학교사: 미술 기초 ~ 포트폴리오 지도</p>
                         </div>
                         <div class="resume-item">
-                            <img src="ck_logo.jpg" alt="청강문화산업대학" class="school-logo">
+                            <img src="ck_logo.jpg" alt="청강문화산업대학" class="school-logo school-logo-sm">
                             <h4>청강문화산업대학교</h4>
                             <p class="resume-period">2025.07 - 현재</p>
                             <p class="resume-desc">졸업생 특화 프로그램 포트폴리오 멘토링</p>
                         </div>
                         <div class="resume-item">
-                            <img src="ck_logo.jpg" alt="청강문화산업대학" class="school-logo">
+                            <img src="ck_logo.jpg" alt="청강문화산업대학" class="school-logo school-logo-sm">
                             <h4>청강문화산업대학</h4>
                             <p class="resume-period">2022.03 - 2023.08</p>
                             <p class="resume-desc">강사, 겸임교수: 3D그래픽연출, 3D모델링기초, 2D게임그래픽포트폴리오</p>

--- a/style.css
+++ b/style.css
@@ -737,6 +737,12 @@ nav {
     pointer-events: none;
 }
 
+/* Smaller watermark for square emblems that otherwise get clipped (홍익대·청강대) */
+.school-logo-sm {
+    width: 60px;
+    height: 60px;
+}
+
 .resume-item h4 {
     font-family: 'Pretendard', sans-serif;
     font-size: 1rem;


### PR DESCRIPTION
## 요약

홍익대·청강대 워터마크 로고가 잘리는 문제 수정.

- 두 로고는 정사각형 엠블럼이라 120px 워터마크 박스를 꽉 채워서, 짧은 항목에선 `overflow: hidden`에 코너가 잘렸음
- `school-logo-sm` modifier(60px = 50%)를 홍익대(Education 2곳)·청강대(강의/멘토링 2곳) 로고에만 적용
- 나머지 로고(와일드플랜·애니모카·라인·게임마이스터고·가포고)는 120px 유지

https://claude.ai/code/session_01S4SVukj8bG7D9qpNA7XQkX

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4SVukj8bG7D9qpNA7XQkX)_