### PR TITLE
Rebrand: 스튜디오아련 → Studio Penumbra

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-studioaryeon.com
+studiopenumbra.com

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-studiopenumbra.com
+studio-penumbra.com

--- a/index.html
+++ b/index.html
@@ -3,7 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>김소연 - Portfolio</title>
+    <title>김소연 | Studio Penumbra</title>
+    <meta name="description" content="김소연 포트폴리오 · Studio Penumbra — 컴퓨터 그래픽스 연구와 인터랙티브 웹 데모.">
+    <meta property="og:site_name" content="Studio Penumbra">
+    <meta property="og:title" content="김소연 | Studio Penumbra">
+    <meta property="og:description" content="김소연 포트폴리오 · Studio Penumbra — 컴퓨터 그래픽스 연구와 인터랙티브 웹 데모.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://studiopenumbra.com/">
+    <meta property="og:image" content="https://studiopenumbra.com/favicon.png">
+    <meta name="twitter:card" content="summary">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png">
     <link rel="icon" type="image/png" sizes="512x512" href="favicon.png">
     <link rel="apple-touch-icon" href="apple-touch-icon.png">
@@ -617,7 +625,7 @@
     <!-- Footer -->
     <footer>
         <div class="container">
-            <p>&copy; 2024 김소연. All rights reserved.</p>
+            <p>&copy; 2026 Studio Penumbra · 김소연. All rights reserved.</p>
         </div>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -435,7 +435,7 @@
                         <p>이 포트폴리오 사이트 자체를 바이브 코딩으로 제작했습니다.</p>
                     </div>
                     <div class="info-actions">
-                        <a href="https://studioaryeon.com/" class="portfolio-btn portfolio-btn-primary" target="_blank">
+                        <a href="/" class="portfolio-btn portfolio-btn-primary" target="_blank">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
                             Visit Site
                         </a>
@@ -450,7 +450,7 @@
                         <p>Disney BRDF 모델 기반 인터랙티브 시뮬레이터입니다.</p>
                     </div>
                     <div class="info-actions">
-                        <a href="https://studioaryeon.com/brdf-viewer.html" class="portfolio-btn portfolio-btn-primary" target="_blank">
+                        <a href="/brdf-viewer.html" class="portfolio-btn portfolio-btn-primary" target="_blank">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
                             Launch Viewer
                         </a>
@@ -465,7 +465,7 @@
                         <p>평면 폴리곤 한 장에 프래그먼트 셰이더로 창문 너머 방 내부를 그리는 인터랙티브 WebGL 데모입니다.<br>해석적 ray-box 교차로 패럴랙스를 만들고, 슬랩/아틀라스 텍스처 샘플링 위에 유리 프레넬 반사·먼지 레이어를 얹었습니다.</p>
                     </div>
                     <div class="info-actions">
-                        <a href="https://studioaryeon.com/interior-mapping.html" class="portfolio-btn portfolio-btn-primary" target="_blank">
+                        <a href="/interior-mapping.html" class="portfolio-btn portfolio-btn-primary" target="_blank">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
                             Launch Demo
                         </a>
@@ -499,7 +499,7 @@
                         <p>좀비 아포칼립스 생존 마을을 30일간 운영하는 텍스트 기반 웹게임입니다. 식량·체력·사기 3축과 분기 선택에 따라 5가지 엔딩으로 갈립니다.<br>홍익대학교 대학원 게임 디자인 과제 『폐허의 불빛 v1.2』의 웹 구현체입니다.</p>
                     </div>
                     <div class="info-actions">
-                        <a href="https://studioaryeon.com/light-of-ruins/" class="portfolio-btn portfolio-btn-primary" target="_blank">
+                        <a href="/light-of-ruins/" class="portfolio-btn portfolio-btn-primary" target="_blank">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>
                             Play Game
                         </a>

--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
     <meta property="og:title" content="김소연 | Studio Penumbra">
     <meta property="og:description" content="김소연 포트폴리오 · Studio Penumbra — 컴퓨터 그래픽스 연구와 인터랙티브 웹 데모.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://studiopenumbra.com/">
-    <meta property="og:image" content="https://studiopenumbra.com/favicon.png">
+    <meta property="og:url" content="https://studio-penumbra.com/">
+    <meta property="og:image" content="https://studio-penumbra.com/favicon.png">
     <meta name="twitter:card" content="summary">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png">
     <link rel="icon" type="image/png" sizes="512x512" href="favicon.png">


### PR DESCRIPTION
## 스튜디오아련 → Studio Penumbra 리브랜딩

도메인은 **`studio-penumbra.com`** 로 등록됨 (`studiopenumbra.com`은 선점됨).

### ⚠️ 머지 전 필수 — DNS부터 연결
이 PR은 `CNAME`을 `studio-penumbra.com`으로 바꿉니다. **DNS(A 레코드 4개 + `www` CNAME)가 실제로 연결된 뒤에 머지하세요.** DNS가 안 된 상태로 머지하면 커스텀 도메인이 연결될 때까지 사이트는 `aryeon0228.github.io`로만 접속됩니다.

필요한 DNS 레코드:
```
A  @  185.199.108.153
A  @  185.199.109.153
A  @  185.199.110.153
A  @  185.199.111.153
CNAME  www  aryeon0228.github.io
```

### 변경 내용
- **내부 링크 4곳** 절대주소(`studioaryeon.com`) → 상대주소로 변경 → 도메인 바뀌어도 안 깨짐
- **타이틀/메타/OG 태그** 추가 (기존엔 없었음) → "Studio Penumbra" 브랜딩, OG url/image는 `studio-penumbra.com`
- **푸터** `© 2026 Studio Penumbra · 김소연`로 갱신 (본인 이름 유지)
- **CNAME** → `studio-penumbra.com`

### 결정 사항
- GitHub 계정명(`Aryeon0228`)은 **유지** (커스텀 도메인 쓰면 방문자에 안 보임)
- 네비 로고("김소연")는 개인 정체성이라 **유지**

🤖 Generated with [Claude Code](https://claude.com/claude-code)