### PR TITLE
Refine Westworld scholarship award entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,7 +308,7 @@
                 <div class="script-row info-row">
                     <span class="script-badge">2025.09</span>
                     <div class="info-main">
-                        <h4>웨스트월드 기부장학금</h4>
+                        <h4>(주)웨스트월드 기부장학금</h4>
                         <p>홍익대학교 영상·커뮤니케이션대학원</p>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -317,6 +317,25 @@
             <h3 class="section-subtitle">Publications</h3>
             <div class="script-list">
                 <div class="script-row info-row">
+                    <span class="script-badge">2026.07</span>
+                    <div class="info-main">
+                        <h4>PBR 텍스처에서 사실적 표현과 양식화 표현의 인지 전환점 연구: 재질별 양식화 단계 비교를 중심으로 <span class="award-badge">석사학위논문</span></h4>
+                        <p class="info-venue">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg>
+                            홍익대학교 영상·커뮤니케이션대학원 · 게임 콘텐츠 전공
+                        </p>
+                        <p class="info-meta">A Study on Perceptual Transition Points between Realistic and Stylized Representations in PBR Textures · 지도교수 김현석</p>
+                    </div>
+                    <!-- 원문 링크: 학교 도서관 등재 후 아래 주석을 해제하고 LIBRARY_URL을 교체하세요
+                    <div class="info-actions">
+                        <a href="LIBRARY_URL" class="portfolio-btn portfolio-btn-primary" target="_blank" rel="noopener">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
+                            원문
+                        </a>
+                    </div>
+                    -->
+                </div>
+                <div class="script-row info-row">
                     <span class="script-badge">2025.12</span>
                     <div class="info-main">
                         <h4>색채 기반 모바일 퍼즐게임 개발과정 연구: Practice-Based Research를 통한 게임 메커니즘 구축 사례 <span class="award-badge">학술지</span></h4>

--- a/index.html
+++ b/index.html
@@ -308,8 +308,8 @@
                 <div class="script-row info-row">
                     <span class="script-badge">2025.09</span>
                     <div class="info-main">
-                        <h4>(주)웨스트월드 기부장학금</h4>
-                        <p>홍익대학교 영상·커뮤니케이션대학원</p>
+                        <h4>2025-2학기 (주)웨스트월드 기부장학금</h4>
+                        <p>홍익대학교 영상·커뮤니케이션대학원 장학생 선정</p>
                     </div>
                 </div>
                 <div class="script-row info-row">

--- a/index.html
+++ b/index.html
@@ -313,8 +313,8 @@
                 </div>
             </div>
 
-            <!-- Research Papers Section -->
-            <h3 class="section-subtitle">Research Papers</h3>
+            <!-- Publications Section -->
+            <h3 class="section-subtitle">Publications</h3>
             <div class="script-list">
                 <div class="script-row info-row">
                     <span class="script-badge">2025.12</span>

--- a/index.html
+++ b/index.html
@@ -306,6 +306,13 @@
                     </div>
                 </div>
                 <div class="script-row info-row">
+                    <span class="script-badge">2025.09</span>
+                    <div class="info-main">
+                        <h4>웨스트월드 기부장학금</h4>
+                        <p>홍익대학교 영상·커뮤니케이션대학원</p>
+                    </div>
+                </div>
+                <div class="script-row info-row">
                     <span class="script-badge">2018.09</span>
                     <div class="info-main">
                         <h4>BIC 2018 EXCELLENCE IN CASUAL</h4>

--- a/style.css
+++ b/style.css
@@ -1103,7 +1103,7 @@ nav {
     }
 }
 
-/* Info Row (Awards / Research Papers / Web·App) — shares the script-row look */
+/* Info Row (Awards / Publications / Web·App) — shares the script-row look */
 .info-row .script-badge {
     align-self: flex-start;
     margin-top: 0.15rem;


### PR DESCRIPTION
## 변경 사항

Awards의 (주)웨스트월드 기부장학금 항목을 다듬음:

- 제목: `2025-2학기 (주)웨스트월드 기부장학금` (학기 정보 추가, 연도는 배지에 위임)
- 설명: `홍익대학교 영상·커뮤니케이션대학원 장학생 선정`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gtc2RZfqgfhCHpxozpx9H2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtc2RZfqgfhCHpxozpx9H2)_