### PR TITLE
Resume 교육 항목 수정 + 가포고 로고 축소

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,9 +99,9 @@
                     </h3>
                     <div class="resume-item">
                         <img src="hongik_emblem_black.png" alt="홍익대학교" class="school-logo school-logo-sm">
-                        <h4>홍익대학교 영상커뮤니케이션대학원<br>게임콘텐츠과</h4>
+                        <h4>홍익대학교 영상커뮤니케이션대학원 게임콘텐츠학부</h4>
                         <p class="resume-period">2024.03 - 2026.08</p>
-                        <p class="resume-desc">석사 졸업예정</p>
+                        <p class="resume-desc">미술학석사 (예정)</p>
                     </div>
                     <div class="resume-item">
                         <img src="hongik_emblem_black.png" alt="홍익대학교" class="school-logo school-logo-sm">
@@ -110,7 +110,7 @@
                         <p class="resume-desc">미술학사</p>
                     </div>
                     <div class="resume-item">
-                        <img src="gapo_logo.png" alt="마산가포고등학교" class="school-logo">
+                        <img src="gapo_logo.png" alt="마산가포고등학교" class="school-logo school-logo-sm">
                         <h4>마산가포고등학교</h4>
                         <p class="resume-period">2000.03 - 2003.03</p>
                     </div>


### PR DESCRIPTION
## Resume — Education 섹션 수정

### 변경 내용
- **홍익대 대학원 학과명:** `영상커뮤니케이션대학원 게임콘텐츠과` → `영상커뮤니케이션대학원 게임콘텐츠학부`, `<br>` 제거해서 **한 줄**로 표시
- **학위 표기:** `석사 졸업예정` → `미술학석사 (예정)`
- **마산가포고등학교 로고:** `school-logo-sm` 클래스 추가 → 다른 워터마크 로고(홍익·청강)처럼 60×60으로 축소

최신 `main`(헤더 로고 변경 #159 포함) 기준으로 작업했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Te6xiMQTAdsGzbHTex33GW)_