### PR TITLE
홍익대 대학원 학과명 정정 (영상·커뮤니케이션대학원 · 게임 콘텐츠 전공)

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
                     </h3>
                     <div class="resume-item">
                         <img src="hongik_emblem_black.png" alt="홍익대학교" class="school-logo school-logo-sm">
-                        <h4>홍익대학교 영상커뮤니케이션대학원 게임콘텐츠학부</h4>
+                        <h4>홍익대학교 영상·커뮤니케이션대학원 · 게임 콘텐츠 전공</h4>
                         <p class="resume-period">2024.03 - 2026.08</p>
                         <p class="resume-desc">미술학석사 (예정)</p>
                     </div>


### PR DESCRIPTION
## Resume — Education 학과명 정정

`홍익대학교 영상커뮤니케이션대학원 게임콘텐츠학부` → **`홍익대학교 영상·커뮤니케이션대학원 · 게임 콘텐츠 전공`**

실제 학과 명칭에 맞춰 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Te6xiMQTAdsGzbHTex33GW)_