### PR TITLE
Shrink hero portrait size

### DIFF
--- a/style.css
+++ b/style.css
@@ -445,7 +445,7 @@ nav {
 
 .hero-image img {
     width: 100%;
-    max-width: 400px;
+    max-width: 340px;
     position: relative;
     z-index: 1;
 }


### PR DESCRIPTION
## Summary

Reduces the hero portrait display size so it feels less dominant on the landing section.

## Changes

- `.hero-image img` `max-width`: 400px → **340px** (`style.css`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ)_