### PR TITLE
Swap favicon to Penumbra icon and shrink hero portrait to 250px

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,9 @@
     <meta property="og:url" content="https://studio-penumbra.com/">
     <meta property="og:image" content="https://studio-penumbra.com/favicon.png">
     <meta name="twitter:card" content="summary">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png">
-    <link rel="icon" type="image/png" sizes="512x512" href="favicon.png">
-    <link rel="apple-touch-icon" href="apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="Penumbra_Pavicon.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="Penumbra_Pavicon.png">
+    <link rel="apple-touch-icon" href="Penumbra_Pavicon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Pretendard:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/style.css
+++ b/style.css
@@ -445,7 +445,7 @@ nav {
 
 .hero-image img {
     width: 100%;
-    max-width: 340px;
+    max-width: 250px;
     position: relative;
     z-index: 1;
 }


### PR DESCRIPTION
## Summary

- Replaces the site favicon with the new `Penumbra_Pavicon.png`.
- Further reduces the hero portrait display size, per request.

## Changes

- `index.html`: point all icon links (32px, 512px, apple-touch-icon) to `Penumbra_Pavicon.png`
- `style.css`: `.hero-image img` `max-width` 340px → **250px**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ)_