### PR TITLE
Update og:image to Penumbra icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta property="og:description" content="김소연 포트폴리오 · Studio Penumbra — 컴퓨터 그래픽스 연구와 인터랙티브 웹 데모.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://studio-penumbra.com/">
-    <meta property="og:image" content="https://studio-penumbra.com/favicon.png">
+    <meta property="og:image" content="https://studio-penumbra.com/Penumbra_Pavicon.png">
     <meta name="twitter:card" content="summary">
     <link rel="icon" type="image/png" sizes="32x32" href="Penumbra_Pavicon.png">
     <link rel="icon" type="image/png" sizes="512x512" href="Penumbra_Pavicon.png">


### PR DESCRIPTION
## Summary

Points the social share preview image (`og:image`) to `Penumbra_Pavicon.png` for brand consistency with the new favicon.

## Changes

- `index.html`: `og:image` → `https://studio-penumbra.com/Penumbra_Pavicon.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ)_