### PR TITLE
Restore hero portrait to original 400px size

### DIFF
--- a/style.css
+++ b/style.css
@@ -445,7 +445,7 @@ nav {
 
 .hero-image img {
     width: 100%;
-    max-width: 250px;
+    max-width: 400px;
     position: relative;
     z-index: 1;
 }


### PR DESCRIPTION
## Summary

Restores the hero portrait display size back to the original 400px now that Photo01 is the active image.

## Changes

- `style.css`: `.hero-image img` `max-width` 250px → **400px**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ)_