### PR TITLE
Add Penumbra icon next to header logo text

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     <!-- Header -->
     <header>
         <nav class="container">
-            <div class="logo">Studio Penumbra</div>
+            <div class="logo"><img src="Penumbra_Pavicon.png" alt="" class="logo-icon">Studio Penumbra</div>
             <div class="nav-right">
                 <ul class="nav-menu">
                     <li><a href="#" id="homeLink">Home</a></li>

--- a/style.css
+++ b/style.css
@@ -184,6 +184,9 @@ nav {
 }
 
 .logo {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
     font-family: 'Pretendard', sans-serif;
     font-size: 1.75rem;
     font-weight: 800;
@@ -191,6 +194,12 @@ nav {
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
+}
+
+.logo-icon {
+    height: 1.4em;
+    width: auto;
+    flex-shrink: 0;
 }
 
 .nav-right {


### PR DESCRIPTION
## Summary

Adds the Penumbra favicon icon to the left of the "Studio Penumbra" wordmark in the header, sized to match the logo text.

## Changes

- `index.html`: add `<img class="logo-icon">` before the logo text
- `style.css`: make `.logo` a flex row (`align-items: center`, `gap: 0.4em`); add `.logo-icon { height: 1.4em }` so the icon scales with the logo font size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ)_