### PR TITLE
Expand BRDF Simulator description

### DIFF
--- a/index.html
+++ b/index.html
@@ -462,7 +462,7 @@
                     <span class="script-badge">WebGL</span>
                     <div class="info-main">
                         <h4>BRDF Simulator</h4>
-                        <p>Disney BRDF 모델 기반 인터랙티브 시뮬레이터입니다.</p>
+                        <p>실시간 WebGL 렌더링으로 동작하는 Disney BRDF(Principled BRDF) 기반 물리 기반 렌더링(PBR) 머티리얼 시뮬레이터입니다. Metallic·Roughness·Clearcoat 등 핵심 셰이딩 파라미터를 슬라이더로 직접 조절하며 빛의 반사를 실시간으로 관찰할 수 있고, 금·은·구리·알루미늄·청동 등 다양한 금속 프리셋과 녹슬음·산화·녹청 같은 풍화 변형까지 제공합니다. PBR/BRDF 이론을 정리한 가이드도 내장돼 있어 학습용으로도 활용할 수 있습니다.</p>
                     </div>
                     <div class="info-actions">
                         <a href="/brdf-viewer.html" class="portfolio-btn portfolio-btn-primary" target="_blank">


### PR DESCRIPTION
## Summary

Expands the BRDF Simulator portfolio blurb from a single line into a richer description that better showcases the project.

## Changes

- `index.html`: BRDF Simulator `<p>` now highlights real-time WebGL PBR rendering, adjustable shading parameters (Metallic/Roughness/Clearcoat), metal presets (gold, silver, copper, aluminum, bronze) with weathering variants, and the built-in PBR/BRDF guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ)_