### PR TITLE
Add Korean description to BIC 2018 award entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,7 +316,7 @@
                     <span class="script-badge">2018.09</span>
                     <div class="info-main">
                         <h4>BIC 2018 EXCELLENCE IN CASUAL</h4>
-                        <p>Colorzzle</p>
+                        <p>Colorzzle · 부산인디커넥트페스티벌(BIC) 탁월한 캐주얼 부문 수상</p>
                     </div>
                 </div>
                 <div class="script-row info-row">


### PR DESCRIPTION
## Summary

Adds a Korean explanation to the BIC 2018 award entry so the English title is clearer.

## Changes

- `index.html`: Colorzzle award line → `Colorzzle · 부산인디커넥트페스티벌(BIC) 탁월한 캐주얼 부문 수상`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ)_