### PR TITLE
Unify Cheongkang name and add dept to lecturer entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,13 +274,13 @@
                         </div>
                         <div class="resume-item">
                             <img src="ck_logo.jpg" alt="청강문화산업대학" class="school-logo school-logo-sm">
-                            <h4>청강문화산업대학교</h4>
+                            <h4>청강문화산업대학</h4>
                             <p class="resume-period">2025.07 - 현재</p>
                             <p class="resume-desc">졸업생 특화 프로그램 포트폴리오 멘토링</p>
                         </div>
                         <div class="resume-item">
                             <img src="ck_logo.jpg" alt="청강문화산업대학" class="school-logo school-logo-sm">
-                            <h4>청강문화산업대학</h4>
+                            <h4>청강문화산업대학 <span class="resume-role">게임콘텐츠</span></h4>
                             <p class="resume-period">2022.03 - 2023.08</p>
                             <p class="resume-desc">강사, 겸임교수: 3D그래픽연출, 3D모델링기초, 2D게임그래픽포트폴리오</p>
                         </div>


### PR DESCRIPTION
## Summary

Normalizes the Cheongkang school name and clarifies the lecturer entry's department.

## Changes

- `index.html`: 청강문화산업대학**교** → 청강문화산업대학 (mentoring entry) for consistent naming
- `index.html`: lecturer entry now shows `청강문화산업대학 게임콘텐츠`, with 게임콘텐츠 styled as a gray `resume-role` department label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ)_