### PR TITLE
Fix lecturer dept label to 게임스쿨

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@
                         </div>
                         <div class="resume-item">
                             <img src="ck_logo.jpg" alt="청강문화산업대학" class="school-logo school-logo-sm">
-                            <h4>청강문화산업대학 <span class="resume-role">게임콘텐츠</span></h4>
+                            <h4>청강문화산업대학 <span class="resume-role">게임스쿨</span></h4>
                             <p class="resume-period">2022.03 - 2023.08</p>
                             <p class="resume-desc">강사, 겸임교수: 3D그래픽연출, 3D모델링기초, 2D게임그래픽포트폴리오</p>
                         </div>


### PR DESCRIPTION
## Summary

Corrects the lecturer entry department label from 게임콘텐츠 to 게임스쿨.

## Changes

- `index.html`: 청강문화산업대학 `게임콘텐츠` → `게임스쿨`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ)_