### PR TITLE
Add About section, make logo link home, swap Home nav for About

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,10 +31,10 @@
     <!-- Header -->
     <header>
         <nav class="container">
-            <div class="logo"><img src="Penumbra_Pavicon.png" alt="" class="logo-icon">Studio Penumbra</div>
+            <a href="#" class="logo" id="logoHome"><img src="Penumbra_Pavicon.png" alt="" class="logo-icon">Studio Penumbra</a>
             <div class="nav-right">
                 <ul class="nav-menu">
-                    <li><a href="#" id="homeLink">Home</a></li>
+                    <li><a href="#about">About</a></li>
                     <li><a href="#resume">Resume</a></li>
                     <li><a href="#portfolio">Portfolio</a></li>
                     <li><a href="#vibe">Vibe Coding</a></li>
@@ -79,6 +79,16 @@
                     <img src="Photo01.png" alt="김소연">
                 </div>
             </div>
+        </div>
+    </section>
+
+    <!-- About Section -->
+    <section id="about" class="section">
+        <div class="container">
+            <h2 class="section-title">About</h2>
+            <p class="about-lead">Studio Penumbra는 빛과 그림자가 만나는 경계, '반그림자(penumbra)'에서 이름을 딴 1인 크리에이티브 스튜디오입니다.</p>
+            <p class="about-text">실시간 그래픽스와 게임 아트, 그리고 웹 위에서 돌아가는 작은 인터랙티브 실험들을 만듭니다. 3D 모델링과 테크니컬 아트부터 셰이더·렌더링 연구까지, 한 픽셀의 음영까지 들여다보는 일을 좋아합니다.</p>
+            <p class="about-text">작은 스튜디오지만, 보기 좋은 것과 잘 돌아가는 것 사이를 잇는 일에는 진심입니다.</p>
         </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -361,11 +361,11 @@ if (themeToggle) {
     }
 })();
 
-// ==================== Home Link ====================
-const homeLink = document.getElementById('homeLink');
+// ==================== Logo → Home ====================
+const logoHome = document.getElementById('logoHome');
 
-if (homeLink) {
-    homeLink.addEventListener('click', (e) => {
+if (logoHome) {
+    logoHome.addEventListener('click', (e) => {
         e.preventDefault();
         window.scrollTo({
             top: 0,
@@ -397,8 +397,10 @@ if (mobileToggle && navMenu) {
 // ==================== Smooth Scroll for Navigation ====================
 document.querySelectorAll('a[href^="#"]').forEach(anchor => {
     anchor.addEventListener('click', function (e) {
+        const href = this.getAttribute('href');
+        if (!href || href === '#') return;
         e.preventDefault();
-        const target = document.querySelector(this.getAttribute('href'));
+        const target = document.querySelector(href);
         if (target) {
             const headerOffset = 80;
             const elementPosition = target.getBoundingClientRect().top;

--- a/style.css
+++ b/style.css
@@ -194,12 +194,32 @@ nav {
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
+    text-decoration: none;
+    cursor: pointer;
 }
 
 .logo-icon {
     height: 1.4em;
     width: auto;
     flex-shrink: 0;
+}
+
+.about-lead {
+    font-family: 'Pretendard', sans-serif;
+    font-size: 1.5rem;
+    font-weight: 700;
+    line-height: 1.5;
+    max-width: 760px;
+    margin-bottom: var(--spacing-md);
+    color: var(--text-primary);
+}
+
+.about-text {
+    font-size: 1.05rem;
+    line-height: 1.8;
+    max-width: 760px;
+    margin-bottom: var(--spacing-sm);
+    color: var(--text-secondary);
 }
 
 .nav-right {


### PR DESCRIPTION
## Summary

Introduces an About section for Studio Penumbra and reworks the header navigation so the logo acts as the home button.

## Changes

- **Logo → Home**: header logo is now an `<a id="logoHome">` that smooth-scrolls to the top.
- **Nav**: replaced the `Home` item with `About` (→ `#about`).
- **About section**: new `#about` section below the hero with brand-story copy ("반그림자" name story + what the studio makes).
- **Bug guard**: the smooth-scroll handler now ignores `href="#"`, avoiding a `querySelector('#')` error that previously fired on the old Home link.
- `style.css`: added `.about-lead` / `.about-text` styles and `text-decoration: none; cursor: pointer` on `.logo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ)_