### PR TITLE
Refine About copy: triad + education, smoother closing line

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,8 @@
             <h2 class="section-title">About</h2>
             <p class="about-lead">Studio Penumbra는 빛과 그림자가 만나는 경계, '반그림자(penumbra)'에서 이름을 딴 1인 크리에이티브 스튜디오입니다.</p>
             <p class="about-text">실시간 그래픽스와 게임 아트, 그리고 웹 위에서 돌아가는 작은 인터랙티브 실험들을 만듭니다. 3D 모델링과 테크니컬 아트부터 셰이더·렌더링 연구까지, 한 픽셀의 음영까지 들여다보는 일을 좋아합니다.</p>
-            <p class="about-text">작은 스튜디오지만, 보기 좋은 것과 잘 돌아가는 것 사이를 잇는 일에는 진심입니다.</p>
+            <p class="about-text">게임과 그래픽스를 만드는 <strong>실무</strong>, 더 나은 표현을 찾는 <strong>연구</strong>, 그리고 배운 것을 나누는 <strong>강의</strong> — 이 세 가지를 함께 이어가고 있습니다. 홍익대학교에서 애니메이션을 전공하고 같은 대학원에서 게임 콘텐츠로 석사 과정을 밟으며, 청강문화산업대학 게임스쿨에서 학생들을 가르쳐 왔습니다.</p>
+            <p class="about-text">작은 스튜디오지만, 일에 진심을 다하고 있습니다.</p>
         </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -222,6 +222,11 @@ nav {
     color: var(--text-secondary);
 }
 
+.about-text strong {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
 .nav-right {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary

Polishes the About section copy per feedback: a less awkward closing line and a new paragraph weaving in the practice/research/teaching identity and education history.

## Changes

- `index.html`: closing line → "작은 스튜디오지만, 일에 진심을 다하고 있습니다."
- `index.html`: added a paragraph highlighting 실무·연구·강의 and education (Hongik animation BFA → game-content MFA in progress, lecturing at Cheongkang Game School).
- `style.css`: `.about-text strong` styled in primary color to make the 실무·연구·강의 keywords stand out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ)_