### PR TITLE
Trim duplicated education sentence from About

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
             <h2 class="section-title">About</h2>
             <p class="about-lead">Studio Penumbra는 빛과 그림자가 만나는 경계, '반그림자(penumbra)'에서 이름을 딴 1인 크리에이티브 스튜디오입니다.</p>
             <p class="about-text">실시간 그래픽스와 게임 아트, 그리고 웹 위에서 돌아가는 작은 인터랙티브 실험들을 만듭니다. 3D 모델링과 테크니컬 아트부터 셰이더·렌더링 연구까지, 한 픽셀의 음영까지 들여다보는 일을 좋아합니다.</p>
-            <p class="about-text">게임과 그래픽스를 만드는 <strong>실무</strong>, 더 나은 표현을 찾는 <strong>연구</strong>, 그리고 배운 것을 나누는 <strong>강의</strong> — 이 세 가지를 함께 이어가고 있습니다. 홍익대학교에서 애니메이션을 전공하고 같은 대학원에서 게임 콘텐츠로 석사 과정을 밟으며, 청강문화산업대학 게임스쿨에서 학생들을 가르쳐 왔습니다.</p>
+            <p class="about-text">게임과 그래픽스를 만드는 <strong>실무</strong>, 더 나은 표현을 찾는 <strong>연구</strong>, 그리고 배운 것을 나누는 <strong>강의</strong> — 이 세 가지를 함께 이어가고 있습니다.</p>
             <p class="about-text">작은 스튜디오지만, 일에 진심을 다하고 있습니다.</p>
         </div>
     </section>


### PR DESCRIPTION
## Summary

Removes the education/teaching history sentence in About since it duplicates the Resume section. The 실무·연구·강의 triad sentence stays.

## Changes

- `index.html`: drop the "홍익대학교에서 애니메이션을 전공하고…가르쳐 왔습니다." sentence from the About paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ)_