### PR TITLE
Tune About typography: smaller font, per-sentence breaks, keep-all

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
         <div class="container">
             <h2 class="section-title">About</h2>
             <p class="about-lead">Studio Penumbra는 빛과 그림자가 만나는 경계, '반그림자(penumbra)'에서 이름을 딴 1인 크리에이티브 스튜디오입니다.</p>
-            <p class="about-text">실시간 그래픽스와 게임 아트, 그리고 웹 위에서 돌아가는 작은 인터랙티브 실험들을 만듭니다. 3D 모델링과 테크니컬 아트부터 셰이더·렌더링 연구까지, 한 픽셀의 음영까지 들여다보는 일을 좋아합니다.</p>
+            <p class="about-text">실시간 그래픽스와 게임 아트, 그리고 웹 위에서 돌아가는 작은 인터랙티브 실험들을 만듭니다.<br>3D 모델링과 테크니컬 아트부터 셰이더·렌더링 연구까지, 한 픽셀의 음영까지 들여다보는 일을 좋아합니다.</p>
             <p class="about-text">게임과 그래픽스를 만드는 <strong>실무</strong>, 더 나은 표현을 찾는 <strong>연구</strong>, 그리고 배운 것을 나누는 <strong>강의</strong> — 이 세 가지를 함께 이어가고 있습니다.</p>
             <p class="about-text">작은 스튜디오지만, 일에 진심을 다하고 있습니다.</p>
         </div>

--- a/style.css
+++ b/style.css
@@ -206,20 +206,22 @@ nav {
 
 .about-lead {
     font-family: 'Pretendard', sans-serif;
-    font-size: 1.5rem;
+    font-size: 1.25rem;
     font-weight: 700;
     line-height: 1.5;
     max-width: 760px;
     margin-bottom: var(--spacing-md);
     color: var(--text-primary);
+    word-break: keep-all;
 }
 
 .about-text {
-    font-size: 1.05rem;
+    font-size: 0.95rem;
     line-height: 1.8;
     max-width: 760px;
     margin-bottom: var(--spacing-sm);
     color: var(--text-secondary);
+    word-break: keep-all;
 }
 
 .about-text strong {


### PR DESCRIPTION
## Summary

Refines the About section typography per request.

## Changes

- `style.css`: smaller fonts — `.about-lead` 1.5→1.25rem, `.about-text` 1.05→0.95rem.
- `style.css`: `word-break: keep-all` on About text so Korean words/phrases don't break mid-word when wrapping.
- `index.html`: break the two-sentence paragraph at the period (`<br>`) so each sentence sits on its own line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcVBQ76iN3f468q5QhqadQ)_