### PR TITLE
Education 섹션 미술학석사에 GPA 뱃지 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
                         <img src="hongik_emblem_black.png" alt="홍익대학교" class="school-logo school-logo-sm">
                         <h4>홍익대학교 영상·커뮤니케이션대학원 · 게임 콘텐츠 전공</h4>
                         <p class="resume-period">2024.03 - 2026.08</p>
-                        <p class="resume-desc">미술학석사 (예정)</p>
+                        <p class="resume-desc">미술학석사 (예정) <span class="gpa-badge" title="졸업 평점 4.28/4.5 · 97.78/100">GPA 4.28<span class="gpa-badge-max">/4.5</span></span></p>
                     </div>
                     <div class="resume-item">
                         <img src="hongik_emblem_black.png" alt="홍익대학교" class="school-logo school-logo-sm">

--- a/style.css
+++ b/style.css
@@ -972,6 +972,27 @@ nav {
     vertical-align: middle;
 }
 
+.gpa-badge {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 1px;
+    background: var(--gradient);
+    color: white;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    padding: 0.12rem 0.45rem;
+    border-radius: 20px;
+    vertical-align: middle;
+    margin-left: 0.35rem;
+    cursor: default;
+}
+
+.gpa-badge-max {
+    font-weight: 500;
+    opacity: 0.85;
+}
+
 .award-group .award-subitem {
     margin-top: 1rem;
     padding-top: 1rem;


### PR DESCRIPTION
## 변경 내용

Education 카드의 **미술학석사 (예정)** 항목 옆에 졸업 평점을 작은 그라데이션 pill 뱃지로 추가했습니다.

- 표시 텍스트: `GPA 4.28/4.5`
- 마우스 호버 시 툴팁: `졸업 평점 4.28/4.5 · 97.78/100`
- 기존 `.award-badge`와 톤을 맞추되, "쪼그맣게" 들어가도록 더 작은 크기(`.gpa-badge`)로 스타일링

## 파일

- `index.html` — 미술학석사 desc에 뱃지 마크업 추가
- `style.css` — `.gpa-badge` / `.gpa-badge-max` 스타일 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYynCWNnyaaHcEySGaarD1

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYynCWNnyaaHcEySGaarD1)_